### PR TITLE
fix: se solucionó el botón de guardar inhabilitado para editar un subnivel en proyecto

### DIFF
--- a/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.html
+++ b/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.html
@@ -102,7 +102,7 @@
     </mat-card-content>
     <mat-card-actions style="text-align: center;">
       <ng-container>
-        <button [disabled]="!formEditar.valid" mat-raised-button color="primary" type="submit" class="col-3 mt-2 mb-3"
+        <button [disabled]="!isFormularioModificado()" mat-raised-button color="primary" type="submit" class="col-3 mt-2 mb-3"
           [mat-dialog-close]="formEditar.value">
           Guardar
         </button>

--- a/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.ts
+++ b/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject, AfterContentChecked, DoCheck } from '@angular/core';
+import { Component, OnInit, Inject, ChangeDetectorRef, AfterContentChecked, DoCheck } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl, Validators, AbstractControl } from '@angular/forms';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatRadioChange } from '@angular/material/radio';
@@ -13,6 +13,7 @@ import Swal from 'sweetalert2';
   styleUrls: ['./editar-dialog.component.scss']
 })
 export class EditarDialogComponent implements OnInit {
+  formularioModificado: boolean = false;
   formEditar: FormGroup;
   aplicativoId: string;
   fechaCreacion: Date;
@@ -67,6 +68,7 @@ export class EditarDialogComponent implements OnInit {
 
   constructor(
     private formBuilder: FormBuilder,
+    private cdRef: ChangeDetectorRef,
     public dialogRef: MatDialogRef<EditarDialogComponent>,
     private request: RequestManager,
     @Inject(MAT_DIALOG_DATA) public data: any) {
@@ -106,6 +108,12 @@ export class EditarDialogComponent implements OnInit {
     });
     this.verificarDetalle();
     this.loadTiposPlan();
+    // Suscribe a los cambios en el formulario
+    this.formEditar.valueChanges.subscribe(() => {
+      this.formularioModificado = true;
+      // Marca el componente para la detección de cambios
+      this.cdRef.detectChanges();
+    });
   }
 
   close(): void {
@@ -120,8 +128,17 @@ export class EditarDialogComponent implements OnInit {
     }
   }
 
+  isFormularioModificado(): boolean {
+    return this.formularioModificado;
+  }
+
+  resetFormularioModificado(): void {
+    this.formularioModificado = false;
+  }
+
   deshacer() {
     this.formEditar.reset();
+    this.resetFormularioModificado();
   }
 
   onChange(event) {


### PR DESCRIPTION
- Se corrigió el error de que al intentar editar un subnivel el botón de guardar estaba inhabilitado, aunque se modificara el formulario.