### PR TITLE
feat: se agregó la funcionalidad de añadir unidades_interes y planes_interes

### DIFF
--- a/src/app/pages/plan/habilitar-reporte/habilitar-reporte.component.html
+++ b/src/app/pages/plan/habilitar-reporte/habilitar-reporte.component.html
@@ -122,8 +122,21 @@
             <mat-datepicker #picker10></mat-datepicker>
           </mat-form-field>
         </div>
-
       </ng-container>
+      <div class="btnUnidades-PlanesProyectos">
+        <button mat-raised-button matPrefix color="primary" [disabled]="tipo !== 'seguimiento' && tipo !== 'formulacion'" (click)="banderaTabla('unidades')">Unidades a las que desea asignar el proceso</button>
+        <button mat-raised-button matPrefix color="primary" [disabled]="tipo !== 'seguimiento' && tipo !== 'formulacion'" (click)="banderaTabla('planes_proyectos')">Planes/proyectos a las que desea asignar el proceso</button>
+      </div>
+      <!-- Tabla Unidades de interés -->
+      <mat-card class="card-oas" [style.width.%]="97"
+      *ngIf="(tipo=='seguimiento' || tipo == 'formulacion') && vigenciaSelected && banderaUnidadesInteres">
+        <app-tabla-unidades (unidadesInteresSeleccionadas)="manejarCambiosUnidadesInteres($event)"></app-tabla-unidades>
+      </mat-card>
+      <!-- Tabla Planes/Proyectos de interés -->
+      <mat-card class="card-oas" [style.width.%]="97"
+        *ngIf="(tipo=='seguimiento' || tipo == 'formulacion') && vigenciaSelected && banderaPlanesInteres">
+          <app-listar-plan [banderaPlanesAccionFuncionamiento]="true" (planesInteresSeleccionados)="manejarCambiosPlanesInteres($event)"></app-listar-plan>
+      </mat-card>
     </form>
   </mat-card-content>
   <mat-card-footer *ngIf="!reporteHabilitado && tipoSelected" style="text-align: center;">
@@ -157,23 +170,6 @@
             <mat-option value="seguimientos">Seguimiento</mat-option>
           </mat-select>
         </mat-form-field>
-        <!-- <mat-form-field appearance="fill" [style.width.%]="100">
-                    <mat-label id="tipo-input-label">Unidades a las que desea asignar el proceso</mat-label>
-                    <mat-select (selectionChange)="onChangeU($event.value)">
-                        <mat-option>--</mat-option>
-                        <mat-option value="unidades">Unidades a las que desea asignar el proceso</mat-option>
-
-                    </mat-select>
-
-                </mat-form-field> -->
-
-        <div class="unidades">
-          <button mat-raised-button matPrefix color="primary" (click)="onChangeU('unidades')">Unidades a las
-            que desea asignar el proceso</button>
-        </div>
-
-
-        <!-- <button class="mat-card">Unidades a las que desea asignar el proceso</button> -->
       </div>
       <ng-container *ngIf="tipoInv=='seguimientos' && vigenciaSelectedInv">
         <div class="container-border">
@@ -277,53 +273,7 @@
       </ng-container>
     </form>
   </mat-card-content>
-  <!-- Tabla-Unidades -->
-
-  <mat-card class="card-oas"
-    *ngIf="(tipoInv=='seguimientos' || tipoInv == 'formulaciones') && vigenciaSelectedInv && unidadSelected">
-    <div class="container-border">
-      <h2 class="titulo">Unidades a asignar</h2>
-
-      <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
-
-        <!-- index -->
-        <ng-container matColumnDef="index" class="num">
-          <th mat-header-cell *matHeaderCellDef>No.</th>
-          <td mat-cell *matCellDef="let element" class="num">{{element.posicion}}
-            <!-- <p *ngIf="element.index!=undefined">
-                            {{element.index}}
-                        </p>
-                        <p *ngIf="element.index==undefined">
-                            {{rowIndex+1}}
-                        </p> -->
-          </td>
-          <td mat-footer-cell *matFooterCellDef class="footer">
-            {{step.footer}}
-          </td>
-        </ng-container>
-        <!-- Unidad Column -->
-        <ng-container matColumnDef="Nombre" class="nombre-unidad">
-          <th mat-header-cell *matHeaderCellDef> Unidad </th>
-          <td mat-cell *matCellDef="let element"> {{element.Nombre}} </td>
-        </ng-container>
-
-        <!-- Seleccionar -->
-        <ng-container matColumnDef="actions" class="col-seleccion">
-          <th mat-header-cell *matHeaderCellDef>Seleccionar</th>
-          <td mat-cell *matCellDef="let row" class="mat-column-actions">
-            <button mat-icon-button (click)="changeIcon(row)">
-              <mat-icon>{{row.iconSelected}}</mat-icon>
-            </button>
-          </td>
-        </ng-container>
-
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-      </table>
-      <mat-paginator [pageSizeOptions]="[10, 20, 30]" aria-label="Select page of Unidades"
-        showFirstLastButtons></mat-paginator>
-    </div>
-  </mat-card>
+  
 
   <mat-card-footer *ngIf="!reporteHabilitado && tipoSelectedInv" style="text-align: center;">
     <button mat-raised-button color="primary" [disabled]="guardarDisabled" (click)="guardarInv()">

--- a/src/app/pages/plan/habilitar-reporte/habilitar-reporte.component.ts
+++ b/src/app/pages/plan/habilitar-reporte/habilitar-reporte.component.ts
@@ -19,23 +19,34 @@ export interface Unidades {
   iconSelected: string;
 }
 
+export interface PeriodoSeguimiento {
+  _id: string
+  fecha_inicio: string
+  fecha_fin: string
+  periodo_id: string
+  tipo_seguimiento_id: string
+  activo: boolean
+  unidades_interes: string
+  planes_interes: string
+  fecha_creacion: string
+  fecha_modificacion: string
+}
+
 export interface Unidad {
   Id: string;
   Nombre: string;
 }
 
-
-
 @Component({
   selector: 'app-habilitar-reporte',
   templateUrl: './habilitar-reporte.component.html',
-  styleUrls: ['./habilitar-reporte.component.scss']
+  styleUrls: ['./habilitar-reporte.component.scss'],
 })
 export class HabilitarReporteComponent implements OnInit {
-
   vigenciaSelected: boolean;
   vigenciaSelectedInv: boolean;
-  unidadSelected: boolean;
+  banderaUnidadesInteres: boolean;
+  banderaPlanesInteres: boolean;
   tipoSelected: boolean;
   tipoSelectedInv: boolean;
   reporteHabilitado: boolean;
@@ -53,6 +64,7 @@ export class HabilitarReporteComponent implements OnInit {
   guardarDisabled: boolean;
   displayedColumns: string[] = ['index', 'Nombre', 'actions'];
   unidadesInteres: any;
+  planesInteres: any;
   dataUnidades: any;
   dataSource = new MatTableDataSource<Unidades>();
 
@@ -66,7 +78,7 @@ export class HabilitarReporteComponent implements OnInit {
 
   constructor(
     private request: RequestManager,
-    private formBuilder: FormBuilder,
+    private formBuilder: FormBuilder
   ) {
     this.loadVigencias();
     this.vigenciaSelected = false;
@@ -97,7 +109,14 @@ export class HabilitarReporteComponent implements OnInit {
       fecha19: ['',],
       fecha20: ['',]
     });
+  }
 
+  manejarCambiosUnidadesInteres(nuevasUnidades: any[]) {
+    this.unidadesInteres = nuevasUnidades;
+  }
+
+  manejarCambiosPlanesInteres(nuevosPlanes: any[]) {
+    this.planesInteres = nuevosPlanes;
   }
 
   loadVigencias() {
@@ -111,33 +130,10 @@ export class HabilitarReporteComponent implements OnInit {
         text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
         icon: 'warning',
         showConfirmButton: false,
-        timer: 2500
-      })
-    })
-  }
-  changeIcon(row: { iconSelected: string; Id: any; Nombre: any; }) {
-    if (row.iconSelected == 'compare_arrows') {
-      row.iconSelected = 'done';
-      let unidad = [];
-      if (this.unidadesInteres[0].Id == undefined) {
-        unidad = [...[{
-          "Id": row.Id,
-          "Nombre": row.Nombre,
-        }]];
-        this.unidadesInteres = unidad;
-      } else {
-        unidad = [...this.unidadesInteres, ...[{
-          "Id": row.Id,
-          "Nombre": row.Nombre,
-        }]];
-        this.unidadesInteres = unidad;
-      }
-    } else if (row.iconSelected == 'done') {
-      row.iconSelected = 'compare_arrows';
-      let unidadEliminar = row.Id;
-      const index = this.unidadesInteres.findIndex((x: { Id: any; }) => x.Id == unidadEliminar);
-      this.unidadesInteres.splice(index, 1);
+        timer: 2500,
+      });
     }
+  );
   }
 
   onChangeV(vigencia: any) {
@@ -147,11 +143,9 @@ export class HabilitarReporteComponent implements OnInit {
       this.vigenciaSelected = true;
       this.vigencia = vigencia;
       this.loadTrimestres(this.vigencia);
-      if (this.tipoSelected)
-        this.loadFechas();
+      if (this.tipoSelected) this.loadFechas();
     }
   }
-
 
   onChange(tipo: string) {
     if (tipo == undefined) {
@@ -173,17 +167,20 @@ export class HabilitarReporteComponent implements OnInit {
     }
   }
 
-  onChangeU(unidad: string) {
-    this.loadUnidades();
-    if (unidad == undefined) {
-      this.unidadSelected = false;
-    } else {
-      this.unidadSelected = true;
-      this.unidad = unidad;
+  banderaTabla(objeto: string) {
+    //Objeto hace referencia a las unidades o proyectos
+    switch (objeto) {
+      case 'unidades':
+        this.banderaUnidadesInteres = true;
+        break;
+      case 'planes_proyectos':
+        this.banderaPlanesInteres = true;
+        break;
+      default:
+        this.banderaUnidadesInteres = false;
+        this.banderaPlanesInteres = false;
     }
   }
-
-
 
   onChangeFF(index: number, event: MatDatepickerInputEvent<Date>) {
     if (index == 1) {
@@ -197,8 +194,7 @@ export class HabilitarReporteComponent implements OnInit {
       this.vigenciaSelectedInv = true;
       this.vigenciaInv = vigencia;
       this.loadTrimestres(this.vigenciaInv);
-      if (this.tipoSelectedInv)
-        this.loadFechasInv();
+      if (this.tipoSelectedInv) this.loadFechasInv();
     }
   }
 
@@ -210,7 +206,7 @@ export class HabilitarReporteComponent implements OnInit {
       willOpen: () => {
         Swal.showLoading();
       },
-    })
+    });
     if (this.tipoInv === 'formulaciones') {
       if (this.periodos && this.periodos.length > 0) {
         this.readUnidadesForm();
@@ -221,8 +217,8 @@ export class HabilitarReporteComponent implements OnInit {
           text: `No se encontraron datos registrados`,
           icon: 'warning',
           showConfirmButton: false,
-          timer: 2500
-        })
+          timer: 2500,
+        });
       }
       this.request.get(environment.PLANES_CRUD, `periodo-seguimiento?query=activo:true,tipo_seguimiento_id:6389efac6a0d190ffb883f71`).subscribe((data: any) => {
         if (data) {
@@ -236,7 +232,6 @@ export class HabilitarReporteComponent implements OnInit {
           } else {
             Swal.close();
           }
-
         }
       }, (error) => {
         Swal.fire({
@@ -255,8 +250,8 @@ export class HabilitarReporteComponent implements OnInit {
           this.request.get(environment.PLANES_CRUD, `periodo-seguimiento?query=activo:true,periodo_id:` + this.periodos[i].Id + `,tipo_seguimiento_id:6385fa136a0d19d7888837ed`).subscribe((data: any) => {
             if (data.Data.length != 0) {
               let seguimiento = data.Data[0];
-              let fechaInicio = new Date(seguimiento["fecha_inicio"]);
-              let fechaFin = new Date(seguimiento["fecha_fin"]);
+                  let fechaInicio = new Date(seguimiento['fecha_inicio']);
+                  let fechaFin = new Date(seguimiento['fecha_fin']);
 
               if (i == 0) {
                 this.formFechas.get('fecha11').setValue(fechaInicio);
@@ -272,7 +267,6 @@ export class HabilitarReporteComponent implements OnInit {
                 this.formFechas.get('fecha18').setValue(fechaFin);
                 Swal.close();
               }
-
             } else {
               Swal.close();
             }
@@ -293,8 +287,8 @@ export class HabilitarReporteComponent implements OnInit {
           text: `No se encuentran trimestres habilitados para esta vigencia`,
           icon: 'warning',
           showConfirmButton: false,
-          timer: 2500
-        })
+          timer: 2500,
+        });
       }
     }
   }
@@ -307,7 +301,7 @@ export class HabilitarReporteComponent implements OnInit {
       willOpen: () => {
         Swal.showLoading();
       },
-    })
+    });
     if (this.tipo === 'formulacion') {
       this.request.get(environment.PLANES_CRUD, `seguimiento?query=activo:true,tipo_seguimiento_id:6260e975ebe1e6498f7404ee`).subscribe((data: any) => {
         if (data) {
@@ -321,7 +315,6 @@ export class HabilitarReporteComponent implements OnInit {
           } else {
             Swal.close();
           }
-
         }
       }, (error) => {
         Swal.fire({
@@ -338,8 +331,8 @@ export class HabilitarReporteComponent implements OnInit {
           this.request.get(environment.PLANES_CRUD, `periodo-seguimiento?query=activo:true,periodo_id:` + this.periodos[i].Id + `,tipo_seguimiento_id:61f236f525e40c582a0840d0`).subscribe((data: any) => {
             if (data.Data.length != 0) {
               let seguimiento = data.Data[0];
-              let fechaInicio = new Date(seguimiento["fecha_inicio"]);
-              let fechaFin = new Date(seguimiento["fecha_fin"]);
+                  let fechaInicio = new Date(seguimiento['fecha_inicio']);
+                  let fechaFin = new Date(seguimiento['fecha_fin']);
 
               if (i == 0) {
                 this.formFechas.get('fecha1').setValue(fechaInicio);
@@ -355,7 +348,6 @@ export class HabilitarReporteComponent implements OnInit {
                 this.formFechas.get('fecha8').setValue(fechaFin);
                 Swal.close();
               }
-
             } else {
               Swal.close();
             }
@@ -376,8 +368,8 @@ export class HabilitarReporteComponent implements OnInit {
           text: `No se encuentran trimestres habilitados para esta vigencia`,
           icon: 'warning',
           showConfirmButton: false,
-          timer: 2500
-        })
+          timer: 2500,
+        });
       }
     }
   }
@@ -451,7 +443,6 @@ export class HabilitarReporteComponent implements OnInit {
         if (data.Data.length != 0) {
           this.unidadesInteres = JSON.parse(data.Data[0].unidades_interes);
           if (data.Data[0].unidades_interes == undefined) {
-
             this.unidadesInteres = ' ';
           }
         } else if (data.Data.length == 0) {
@@ -459,62 +450,51 @@ export class HabilitarReporteComponent implements OnInit {
         }
       }
     }, (error) => {
-      Swal.fire({
-        title: 'Error en la operación',
-        text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
-        icon: 'warning',
-        showConfirmButton: false,
-        timer: 2500
-      })
-    });
+    Swal.fire({
+      title: 'Error en la operación',
+      text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
+      icon: 'warning',
+      showConfirmButton: false,
+          timer: 2500,
+        });
+      }
+    );
   }
 
-  loadUnidades() {
-    this.request.get(environment.PLANES_MID, `formulacion/get_unidades`).subscribe((data: any) => {
-      if (data) {
-        if (data.Data.length != 0) {
-          this.dataUnidades = data.Data;
-          if (this.unidadesInteres.length == 0 || this.unidadesInteres.length == undefined || this.unidadesInteres == ' ') {
-            for (let i = 0; i < this.dataUnidades.length; i++) {
-              this.dataUnidades[i].iconSelected = 'compare_arrows';
-              this.dataUnidades[i].posicion = i + 1;
-            }
-          } else {
-            for (let i = 0; i < this.dataUnidades.length; i++) {
-              for (let j = 0; j < this.unidadesInteres.length; j++) {
-                if (this.unidadesInteres[j].Id == this.dataUnidades[i].Id) {
-                  if (this.dataUnidades[i].iconSelected == 'compare_arrows' || this.dataUnidades[i].iconSelected == '' || this.dataUnidades[i].iconSelected == undefined) {
-                    this.dataUnidades[i].iconSelected = 'done';
-                    this.dataUnidades[i].posicion = i + 1;
-                  }
-                } else if (this.unidadesInteres[j].Id != this.dataUnidades[i].Id) {
-                  if (this.dataUnidades[i].iconSelected == 'done') {
-                    this.dataUnidades[i].posicion = i + 1;
-                  } else if (this.dataUnidades.iconSelected == '' || this.dataUnidades.iconSelected == undefined) {
-                    this.dataUnidades[i].iconSelected = 'compare_arrows';
-                    this.dataUnidades[i].posicion = i + 1;
-                  }
-                }
-              }
-            }
-          }
-          this.dataSource = new MatTableDataSource(this.dataUnidades);
-          this.dataSource.paginator = this.paginator;
-        }
-      }
-    }, (error) => {
-      Swal.fire({
-        title: 'Error en la operación',
-        text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
-        icon: 'warning',
-        showConfirmButton: false,
-        timer: 2500
-      })
-    })
+  // Función para validar un ObjectId
+  isValidObjectId(id: string): boolean {
+    // Utiliza una expresión regular para verificar el formato del ObjectId
+    const objectIdRegex = /^[0-9a-fA-F]{24}$/;
+    
+    // Verifica si el id tiene el formato correcto
+    return objectIdRegex.test(id);
   }
 
   guardar() {
+    if(this.unidadesInteres == undefined){
+      Swal.fire({
+        title: 'Error en la operación',
+        text: `Por favor seleccione las unidades de interés para continuar`,
+        icon: 'warning',
+        showConfirmButton: false,
+        timer: 2500
+      });
+      return;
+    }
+    if(this.planesInteres == undefined){
+      Swal.fire({
+        title: 'Error en la operación',
+        text: `Por favor seleccione los planes de interés para continuar`,
+        icon: 'warning',
+        showConfirmButton: false,
+        timer: 2500
+      });
+      return;
+    }
+
     if (this.tipo == 'formulacion') {
+      var periodo_seguimiento_formulacion: PeriodoSeguimiento;
+      var seguimientoFormulacion;
       Swal.fire({
         title: 'Habilitar Fechas',
         text: `¿Desea habilitar la formulación de planes para la vigencia ` + this.vigencia.Nombre + ` ?`,
@@ -524,31 +504,99 @@ export class HabilitarReporteComponent implements OnInit {
       }).then((result) => {
         if (result.isConfirmed) {
           if (this.formFechas.get('fecha9').value != "" && this.formFechas.get('fecha10').value != "") {
-            this.request.get(environment.PLANES_CRUD, `seguimiento?query=activo:true,tipo_seguimiento_id:6260e975ebe1e6498f7404ee`).subscribe((data: any) => {
+            this.request.get(environment.PLANES_CRUD, `seguimiento?query=activo:true,tipo_seguimiento_id:6260e975ebe1e6498f7404ee`).subscribe(async (data: any) => {
               if (data) {
                 if (data.Data.length > 0) {
-                  let seguimientoFormulacion = data.Data[0];
+                  seguimientoFormulacion = data.Data[0];
                   seguimientoFormulacion["fecha_inicio"] = this.formFechas.get('fecha9').value//.toISOString();
                   seguimientoFormulacion["fecha_fin"] = this.formFechas.get('fecha10').value//.toISOString();
-                  this.request.put(environment.PLANES_CRUD, `seguimiento`, seguimientoFormulacion, seguimientoFormulacion["_id"]).subscribe((data: any) => {
-                    if (data) {
+                  if(this.isValidObjectId(seguimientoFormulacion["periodo_seguimiento_id"])){
+                    this.request.get(environment.PLANES_CRUD, `periodo-seguimiento?query=activo:true,_id:${seguimientoFormulacion["periodo_seguimiento_id"]}`).subscribe((data: any) => {
+                      if (data.Data.length > 0) {
+                        periodo_seguimiento_formulacion = data.Data[0];
+                        periodo_seguimiento_formulacion["periodo_id"] = "46";
+                        periodo_seguimiento_formulacion["fecha_inicio"] = this.formFechas.get('fecha9').value;
+                        periodo_seguimiento_formulacion["fecha_fin"] = this.formFechas.get('fecha10').value;
+                        periodo_seguimiento_formulacion["unidades_interes"] = JSON.stringify(this.unidadesInteres);
+                        periodo_seguimiento_formulacion["planes_interes"] = JSON.stringify(this.planesInteres);
+                        this.request.put(environment.PLANES_CRUD, `periodo-seguimiento`, periodo_seguimiento_formulacion, seguimientoFormulacion["periodo_seguimiento_id"]).subscribe((data: any) => {
+                          if (data) {
+                            this.request.put(environment.PLANES_CRUD, `seguimiento`, seguimientoFormulacion, seguimientoFormulacion['_id']).subscribe((data: any) => {
+                              if (data) {
+                                Swal.fire({
+                                  title: 'Fechas Actualizadas',
+                                  icon: 'success',
+                                  showConfirmButton: false,
+                                  timer: 2500
+                                })
+                              }
+                            }, (error) => {
+                              Swal.fire({
+                                title: 'Error en la operación',
+                                text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
+                                icon: 'warning',
+                                showConfirmButton: false,
+                                timer: 2500
+                              })
+                            })
+                          }
+                        }, (error) => {
+                          Swal.fire({
+                            title: 'Error en la operación',
+                            text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
+                            icon: 'warning',
+                            showConfirmButton: false,
+                            timer: 2500
+                          })
+                        })
+                      }
+                    })
+                  } else { // Si el ObjectId de periodo_seguimiendo_id no es válido, se crea un registro en periodo-seguimiento
+                    seguimientoFormulacion["periodo_seguimiento_id"] = "";
+                    let bodySeguimientoPeriodoFormulacion = {
+                      fecha_inicio: this.formFechas.get('fecha9').value,
+                      fecha_fin: this.formFechas.get('fecha10').value,
+                      periodo_id: "46", //Este periodo_id hace ref. al registro de fechas para proceso de seguimiento de los planes de acción de funcionamiento
+                      tipo_seguimiento_id: "6260e975ebe1e6498f7404ee",
+                      unidades_interes: JSON.stringify(this.unidadesInteres),
+                      planes_interes: JSON.stringify(this.planesInteres),
+                      activo: true,
+                    }
+                    await this.request.post(environment.PLANES_CRUD, `periodo-seguimiento`, bodySeguimientoPeriodoFormulacion).subscribe((data: any) => {
+                      if (data) {
+                        periodo_seguimiento_formulacion = data.Data;
+                        seguimientoFormulacion["periodo_seguimiento_id"] = periodo_seguimiento_formulacion._id;
+                        this.request.put(environment.PLANES_CRUD, `seguimiento`, seguimientoFormulacion, seguimientoFormulacion['_id']).subscribe((data: any) => {
+                          if (data) {
+                            Swal.fire({
+                              title: 'Fechas Actualizadas',
+                              icon: 'success',
+                              showConfirmButton: false,
+                              timer: 2500
+                            })
+                          }
+                        }, (error) => {
+                          Swal.fire({
+                            title: 'Error en la operación',
+                            text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
+                            icon: 'warning',
+                            showConfirmButton: false,
+                            timer: 2500
+                          })
+                        })
+                      }
+                    }, (error) => {
                       Swal.fire({
-                        title: 'Fechas Actualizadas',
-                        icon: 'success',
+                        title: 'Error en la operación',
+                        text: `Por favor intente de nuevo`,
+                        icon: 'warning',
                         showConfirmButton: false,
                         timer: 2500
                       })
-                    }
-                  }, (error) => {
-                    Swal.fire({
-                      title: 'Error en la operación',
-                      text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
-                      icon: 'warning',
-                      showConfirmButton: false,
-                      timer: 2500
                     })
-                  })
-                } else {
+                    
+                  }
+                } else { //Hay que implementar el codigo para insertar unidades y planes de interes
                   let seguimientoFormulacion = {
                     nombre: "Seguimiento Formulación",
                     descripcion: "Fechas para control de formulación",
@@ -598,8 +646,8 @@ export class HabilitarReporteComponent implements OnInit {
               icon: 'error',
               text: `Por favor complete las fechas para continuar`,
               showConfirmButton: false,
-              timer: 2500
-            })
+              timer: 2500,
+            });
           }
         } else if (result.dismiss === Swal.DismissReason.cancel) {
         }
@@ -610,9 +658,9 @@ export class HabilitarReporteComponent implements OnInit {
             icon: 'error',
             text: `${JSON.stringify(error)}`,
             showConfirmButton: false,
-            timer: 2500
-          })
-        }
+            timer: 2500,
+          });
+        };
     } else {
       Swal.fire({
         title: 'Habilitar Fechas',
@@ -622,8 +670,16 @@ export class HabilitarReporteComponent implements OnInit {
         cancelButtonText: `No`,
       }).then((result) => {
         if (result.isConfirmed) {
-          if (this.formFechas.get('fecha1').value != "" && this.formFechas.get('fecha2').value != "" && this.formFechas.get('fecha3').value != "" && this.formFechas.get('fecha4').value != "" && this.formFechas.get('fecha5').value != ""
-            && this.formFechas.get('fecha6').value != "" && this.formFechas.get('fecha7').value != "" && this.formFechas.get('fecha8').value != "") {
+          if (
+            this.formFechas.get('fecha1').value != '' &&
+            this.formFechas.get('fecha2').value != '' &&
+            this.formFechas.get('fecha3').value != '' &&
+            this.formFechas.get('fecha4').value != '' &&
+            this.formFechas.get('fecha5').value != '' &&
+            this.formFechas.get('fecha6').value != '' &&
+            this.formFechas.get('fecha7').value != '' &&
+            this.formFechas.get('fecha8').value != ''
+          ) {
             for (let i = 0; i < this.periodos.length; i++) {
               this.actualizarPeriodo(i, this.periodos[i].Id);
             }
@@ -631,16 +687,16 @@ export class HabilitarReporteComponent implements OnInit {
               title: 'Fechas Actualizadas',
               icon: 'success',
               showConfirmButton: false,
-              timer: 2500
-            })
+              timer: 2500,
+            });
           } else {
             Swal.fire({
               title: 'Error en la operación',
               icon: 'error',
               text: `Por favor complete las fechas para continuar`,
               showConfirmButton: false,
-              timer: 2500
-            })
+              timer: 2500,
+            });
           }
         } else if (result.dismiss === Swal.DismissReason.cancel) {
         }
@@ -651,13 +707,11 @@ export class HabilitarReporteComponent implements OnInit {
             icon: 'error',
             text: `${JSON.stringify(error)}`,
             showConfirmButton: false,
-            timer: 2500
-          })
-        }
+            timer: 2500,
+          });
+        };
     }
-
   }
-
 
   guardarInv() {
     if (this.tipoInv == 'formulaciones') {
@@ -750,8 +804,8 @@ export class HabilitarReporteComponent implements OnInit {
               icon: 'error',
               text: `Por favor complete las fechas para continuar`,
               showConfirmButton: false,
-              timer: 2500
-            })
+              timer: 2500,
+            });
           }
         } else if (result.dismiss === Swal.DismissReason.cancel) {
         }
@@ -762,9 +816,9 @@ export class HabilitarReporteComponent implements OnInit {
             icon: 'error',
             text: `${JSON.stringify(error)}`,
             showConfirmButton: false,
-            timer: 2500
-          })
-        }
+            timer: 2500,
+          });
+        };
     } else if (this.tipoInv == 'seguimientos') {
       Swal.fire({
         title: 'Habilitar Fechas',
@@ -774,8 +828,16 @@ export class HabilitarReporteComponent implements OnInit {
         cancelButtonText: `No`,
       }).then((result) => {
         if (result.isConfirmed) {
-          if (this.formFechas.get('fecha11').value != "" && this.formFechas.get('fecha12').value != "" && this.formFechas.get('fecha13').value != "" && this.formFechas.get('fecha14').value != "" && this.formFechas.get('fecha15').value != ""
-            && this.formFechas.get('fecha16').value != "" && this.formFechas.get('fecha17').value != "" && this.formFechas.get('fecha18').value != "") {
+          if (
+            this.formFechas.get('fecha11').value != '' &&
+            this.formFechas.get('fecha12').value != '' &&
+            this.formFechas.get('fecha13').value != '' &&
+            this.formFechas.get('fecha14').value != '' &&
+            this.formFechas.get('fecha15').value != '' &&
+            this.formFechas.get('fecha16').value != '' &&
+            this.formFechas.get('fecha17').value != '' &&
+            this.formFechas.get('fecha18').value != ''
+          ) {
             for (let i = 0; i < this.periodos.length; i++) {
               this.actualizarPeriodoInv(i, this.periodos[i].Id);
             }
@@ -783,16 +845,16 @@ export class HabilitarReporteComponent implements OnInit {
               title: 'Fechas Actualizadas',
               icon: 'success',
               showConfirmButton: false,
-              timer: 2500
-            })
+              timer: 2500,
+            });
           } else {
             Swal.fire({
               title: 'Error en la operación',
               icon: 'error',
               text: `Por favor complete las fechas para continuar`,
               showConfirmButton: false,
-              timer: 2500
-            })
+              timer: 2500,
+            });
           }
         } else if (result.dismiss === Swal.DismissReason.cancel) {
         }
@@ -803,15 +865,14 @@ export class HabilitarReporteComponent implements OnInit {
             icon: 'error',
             text: `${JSON.stringify(error)}`,
             showConfirmButton: false,
-            timer: 2500
-          })
-        }
+            timer: 2500,
+          });
+        };
     }
-
   }
 
   actualizarPeriodo(i: number, periodoId: number) {
-    let body: { periodo_id: string; fecha_inicio: any; fecha_fin: any; };
+    let body: { periodo_id: string; fecha_inicio: any; fecha_fin: any; unidades_interes: any, planes_interes: any};
     let fecha_inicio, fecha_fin;
     if (i === 0) {
       fecha_inicio = new Date(this.formFechas.get('fecha1').value);
@@ -834,10 +895,12 @@ export class HabilitarReporteComponent implements OnInit {
     }
 
     body = {
-      "periodo_id": periodoId.toString(),
-      "fecha_inicio": fecha_inicio.toISOString(),
-      "fecha_fin": fecha_fin.toISOString()
-    }
+      periodo_id: periodoId.toString(),
+      fecha_inicio: fecha_inicio.toISOString(),
+      fecha_fin: fecha_fin.toISOString(),
+      unidades_interes: JSON.stringify(this.unidadesInteres),
+      planes_interes: JSON.stringify(this.planesInteres),
+    };
 
     this.request.put(environment.PLANES_MID, `seguimiento/habilitar_reportes`, body, "").subscribe(), (error: any) => {
       Swal.fire({
@@ -845,9 +908,9 @@ export class HabilitarReporteComponent implements OnInit {
         icon: 'error',
         text: `${JSON.stringify(error)}`,
         showConfirmButton: false,
-        timer: 2500
-      })
-    }
+          timer: 2500,
+        });
+      };
   }
 
   actualizarPeriodoInv(i: number, periodoId: number) {
@@ -925,19 +988,20 @@ export class HabilitarReporteComponent implements OnInit {
     this.tipoSelectedInv = false;
     this.selectTipoInv.setValue('');
     this.selectVigenciaInv.setValue('--');
-
+    this.unidadesInteres = undefined;
+    this.planesInteres = undefined;
     if (this.tipoInv === 'formulaciones') {
-      this.formFechas.get('fecha19').setValue("");
-      this.formFechas.get('fecha20').setValue("");
+      this.formFechas.get('fecha19').setValue('');
+      this.formFechas.get('fecha20').setValue('');
     } else if (this.tipoInv == 'seguimientos') {
-      this.formFechas.get('fecha11').setValue("");
-      this.formFechas.get('fecha12').setValue("");
-      this.formFechas.get('fecha13').setValue("");
-      this.formFechas.get('fecha14').setValue("");
-      this.formFechas.get('fecha15').setValue("");
-      this.formFechas.get('fecha16').setValue("");
-      this.formFechas.get('fecha17').setValue("");
-      this.formFechas.get('fecha18').setValue("");
+      this.formFechas.get('fecha11').setValue('');
+      this.formFechas.get('fecha12').setValue('');
+      this.formFechas.get('fecha13').setValue('');
+      this.formFechas.get('fecha14').setValue('');
+      this.formFechas.get('fecha15').setValue('');
+      this.formFechas.get('fecha16').setValue('');
+      this.formFechas.get('fecha17').setValue('');
+      this.formFechas.get('fecha18').setValue('');
     }
   }
 
@@ -948,20 +1012,20 @@ export class HabilitarReporteComponent implements OnInit {
     this.tipoSelected = false;
     this.selectTipo.setValue('');
     this.selectVigencia.setValue('--');
-
+    this.unidadesInteres = undefined;
+    this.planesInteres = undefined;
     if (this.tipo === 'formulacion') {
-      this.formFechas.get('fecha9').setValue("");
-      this.formFechas.get('fecha10').setValue("");
+      this.formFechas.get('fecha9').setValue('');
+      this.formFechas.get('fecha10').setValue('');
     } else if (this.tipo == 'seguimiento') {
-      this.formFechas.get('fecha1').setValue("");
-      this.formFechas.get('fecha2').setValue("");
-      this.formFechas.get('fecha3').setValue("");
-      this.formFechas.get('fecha4').setValue("");
-      this.formFechas.get('fecha5').setValue("");
-      this.formFechas.get('fecha6').setValue("");
-      this.formFechas.get('fecha7').setValue("");
-      this.formFechas.get('fecha8').setValue("");
+      this.formFechas.get('fecha1').setValue('');
+      this.formFechas.get('fecha2').setValue('');
+      this.formFechas.get('fecha3').setValue('');
+      this.formFechas.get('fecha4').setValue('');
+      this.formFechas.get('fecha5').setValue('');
+      this.formFechas.get('fecha6').setValue('');
+      this.formFechas.get('fecha7').setValue('');
+      this.formFechas.get('fecha8').setValue('');
     }
   }
 }
-

--- a/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.html
+++ b/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.html
@@ -1,0 +1,47 @@
+<div class="container-border">
+  <h2 class="titulo">Unidades a asignar</h2>
+  <mat-form-field appearance="standard" [style.width.%]="50">
+    <mat-label>Búsqueda</mat-label>
+    <input matInput (keyup)="applyFilter($event)" placeholder="Ej. Unidad" #input/>
+  </mat-form-field>
+  <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+    <!-- index -->
+    <ng-container matColumnDef="index" class="num">
+      <th mat-header-cell *matHeaderCellDef class="num">No.</th>
+      <td mat-cell *matCellDef="let element" class="num">
+        {{ element.posicion }}
+      </td>
+      <td mat-footer-cell *matFooterCellDef class="footer">
+        {{ step.footer }}
+      </td>
+    </ng-container>
+    <!-- Unidad Column -->
+    <ng-container matColumnDef="Nombre" class="nombre-unidad">
+      <th mat-header-cell *matHeaderCellDef>Unidad</th>
+      <td mat-cell *matCellDef="let element">{{ element.Nombre }}</td>
+    </ng-container>
+
+    <!-- Seleccionar -->
+    <ng-container matColumnDef="actions" class="col-seleccion">
+      <th mat-header-cell *matHeaderCellDef>Seleccionar</th>
+      <td mat-cell *matCellDef="let row" class="mat-column-actions">
+        <button mat-icon-button (click)="changeIcon(row)">
+          <mat-icon>{{ row.iconSelected }}</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" colspan="5">No se han encontrado resultados para la búsqueda "{{input.value}}"</td>
+    </tr>
+  </table>
+  <mat-paginator class="paginator"
+    [pageSizeOptions]="[10, 20, 30]"
+    aria-label="Select page of Unidades"
+    showFirstLastButtons
+  ></mat-paginator>
+  <button mat-raised-button color="primary" [disabled]="banderaTodosSeleccionados" (click)="seleccionarTodos()">Seleccionar Todos</button>
+  <button mat-raised-button color="primary" [disabled]="unidadesInteres.length==0" (click)="borrarSeleccion()">Borrar selección</button>
+</div>

--- a/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.scss
+++ b/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.scss
@@ -1,68 +1,60 @@
-table {
+table,
+.paginator {
   width: 80%;
   margin-left: 10%;
 }
 
 th {
   color: white;
-  text-align: center;
+  text-align: center !important;
 }
 
-.btnUnidades-PlanesProyectos {
+.unidades {
   display: flex;
   justify-content: center;
 }
 
-.mat-column-nombre {
-  word-wrap: break-word !important;
-  white-space: unset !important;
-  flex: 0 0 34% !important;
-  width: 34% !important;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
+// .nombre-unidad {
+//   word-wrap: break-word !important;
+//   white-space: unset !important;
+//   flex: 0 0 34% !important;
+//   width: 20% !important;
+//   overflow-wrap: break-word;
+//   word-break: break-word;
+//   -ms-hyphens: auto;
+//   -moz-hyphens: auto;
+//   -webkit-hyphens: auto;
+//   hyphens: auto;
+// }
 
-  word-break: break-word;
-
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
-}
-
-.mat-column-position {
+.mat-column-index {
   word-wrap: break-word !important;
   white-space: unset !important;
   flex: 0 0 6% !important;
-  width: 15% !important;
   overflow-wrap: break-word;
   word-wrap: break-word;
-
   word-break: break-word;
-
   -ms-hyphens: auto;
   -moz-hyphens: auto;
   -webkit-hyphens: auto;
   hyphens: auto;
-
-  text-align: center;
-  justify-content: center;
+  // text-align: center;
+  // justify-content: center;
 }
 
 .mat-column-actions {
+  // background-color: red;
   word-wrap: break-word !important;
   white-space: unset !important;
   flex: 0 0 6% !important;
   width: 10% !important;
   overflow-wrap: break-word;
   word-wrap: break-word;
-
   word-break: break-word;
-
   -ms-hyphens: auto;
   -moz-hyphens: auto;
   -webkit-hyphens: auto;
   hyphens: auto;
-
   text-align: center;
   justify-content: flex-end;
 }
@@ -136,6 +128,7 @@ th {
   margin: 0% 2% 0% 3%;
 }
 
-.num {
+.num, .col-seleccion {
   width: 10%;
+  text-align: center !important;
 }

--- a/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.spec.ts
+++ b/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TablaUnidadesComponent } from './tabla-unidades.component';
+
+describe('TablaUnidadesComponent', () => {
+  let component: TablaUnidadesComponent;
+  let fixture: ComponentFixture<TablaUnidadesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TablaUnidadesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TablaUnidadesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.ts
+++ b/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.ts
@@ -1,0 +1,196 @@
+import {
+  Component,
+  EventEmitter,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { environment } from 'src/environments/environment';
+import { RequestManager } from '../../../services/requestManager';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import Swal from 'sweetalert2';
+
+export interface Unidades {
+  CorreoElectronico: string;
+  DependenciaTipoDependencia: string;
+  Id: number;
+  Nombre: string;
+  TelefonoDependencia: string;
+  TipoDependencia: any;
+  iconSelected: string;
+  posicion: string;
+}
+
+export interface Unidad {
+  Id: string;
+  Nombre: string;
+}
+
+@Component({
+  selector: 'app-tabla-unidades',
+  templateUrl: './tabla-unidades.component.html',
+  styleUrls: ['./tabla-unidades.component.scss'],
+})
+export class TablaUnidadesComponent implements OnInit {
+
+  dataUnidades: any;
+  unidadesInteres: any;
+  displayedColumns: string[] = ['index', 'Nombre', 'actions'];
+  dataSource = new MatTableDataSource<Unidades>();
+  banderaTodosSeleccionados: boolean;
+  filtroDeBusquedaUnidades: string = '';
+
+  @Output() unidadesInteresSeleccionadas = new EventEmitter<any[]>();
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  constructor(private request: RequestManager) {
+    this.unidadesInteres = [];
+    this.loadUnidades();
+    this.banderaTodosSeleccionados = false;
+  }
+
+  ngOnInit(): void {
+    console.log('Inicia el componente Tabla-Unidades');
+  }
+
+  async loadUnidades() {
+    const loadingSwal = Swal.fire({
+      title: 'Cargando unidades',
+      timerProgressBar: true,
+      showConfirmButton: false,
+      willOpen: () => {
+        Swal.showLoading();
+      },
+    });
+    await this.request
+      .get(environment.PLANES_MID, `formulacion/get_unidades`)
+      .subscribe((data: any) => {
+        try {
+          if (data) {
+            if (data.Data.length != 0) {
+              this.dataUnidades = data.Data;
+              if (
+                this.unidadesInteres.length == 0 ||
+                this.unidadesInteres.length == undefined ||
+                this.unidadesInteres == ' '
+              ) {
+                for (let i = 0; i < this.dataUnidades.length; i++) {
+                  this.dataUnidades[i].iconSelected = 'compare_arrows';
+                  this.dataUnidades[i].posicion = i + 1;
+                }
+              } else {
+                for (let i = 0; i < this.dataUnidades.length; i++) {
+                  for (let j = 0; j < this.unidadesInteres.length; j++) {
+                    if (this.unidadesInteres[j].Id == this.dataUnidades[i].Id) {
+                      if (
+                        this.dataUnidades[i].iconSelected == 'compare_arrows' ||
+                        this.dataUnidades[i].iconSelected == '' ||
+                        this.dataUnidades[i].iconSelected == undefined
+                      ) {
+                        this.dataUnidades[i].iconSelected = 'done';
+                        this.dataUnidades[i].posicion = i + 1;
+                      }
+                    } else if (
+                      this.unidadesInteres[j].Id != this.dataUnidades[i].Id
+                    ) {
+                      if (this.dataUnidades[i].iconSelected == 'done') {
+                        this.dataUnidades[i].posicion = i + 1;
+                      } else if (
+                        this.dataUnidades.iconSelected == '' ||
+                        this.dataUnidades.iconSelected == undefined
+                      ) {
+                        this.dataUnidades[i].iconSelected = 'compare_arrows';
+                        this.dataUnidades[i].posicion = i + 1;
+                      }
+                    }
+                  }
+                }
+              }
+              this.dataSource = new MatTableDataSource(this.dataUnidades);
+              this.dataSource.paginator = this.paginator;
+            }
+          }
+        } catch (error) {
+          Swal.fire({
+            title: 'Error en la operación',
+            text: `No se encontraron datos registrados ${JSON.stringify(
+              error
+            )}`,
+            icon: 'warning',
+            showConfirmButton: false,
+            timer: 2500,
+          });
+        } finally {
+          Swal.close();
+        }
+      });
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
+  changeIcon(row: Unidades) {
+    if (row.iconSelected == 'compare_arrows') {
+      row.iconSelected = 'done';
+
+      const nuevaUnidad = {
+        Id: row.Id,
+        Nombre: row.Nombre,
+      };
+
+      this.unidadesInteres = [...this.unidadesInteres, nuevaUnidad];
+    } else if (row.iconSelected == 'done') {
+      row.iconSelected = 'compare_arrows';
+      let unidadEliminar = row.Id;
+      const index = this.unidadesInteres.findIndex(
+        (x: { Id: any }) => x.Id == unidadEliminar
+      );
+      this.unidadesInteres.splice(index, 1);
+    }
+    console.log('Unidades de interes seleccionadas: ', this.unidadesInteres);
+    this.emitirCambiosUnidadesInteres();
+  }
+
+  seleccionarTodos() {
+    this.banderaTodosSeleccionados = true;
+    this.unidadesInteres = this.dataUnidades.map((element) => ({
+      Id: element.Id,
+      Nombre: element.Nombre,
+    }));
+
+    // Itera sobre los elementos y cambia el icono
+    this.dataUnidades.forEach((element) => {
+      element.iconSelected = 'done';
+    });
+
+    // Emite los cambios
+    console.log('Todos seleccionados: ', this.unidadesInteres);
+    this.emitirCambiosUnidadesInteres();
+  }
+
+  borrarSeleccion() {
+    this.banderaTodosSeleccionados = false;
+    // Itera sobre los elementos y cambia el icono a 'compare_arrows'
+    this.dataUnidades.forEach((element) => {
+      element.iconSelected = 'compare_arrows';
+    });
+
+    // Limpia el array de unidades de interés
+    this.unidadesInteres = [];
+
+    // Emite los cambios
+    console.log('Ninguno seleccionado: ', this.unidadesInteres);
+    this.emitirCambiosUnidadesInteres();
+  }
+
+  emitirCambiosUnidadesInteres() {
+    this.unidadesInteresSeleccionadas.emit(this.unidadesInteres);
+  }
+}

--- a/src/app/pages/plan/listar-plan/listar-plan.component.html
+++ b/src/app/pages/plan/listar-plan/listar-plan.component.html
@@ -1,8 +1,8 @@
-<mat-card class="card-oas">
-    <mat-card-header>
+<mat-card class="card-oas" [style.width.%]="97">
+    <mat-card-header *ngIf="!banderaPlanesAccionFuncionamiento">
         <mat-card-title>Listar planes</mat-card-title>
     </mat-card-header>
-    <mat-card-content>
+    <mat-card-content *ngIf="!banderaPlanesAccionFuncionamiento">
         <u class="textGuide">
             En esta sección usted podrá visualizar los planes construidos, con sus características y acciones para cada uno de ellos
         </u>
@@ -18,33 +18,38 @@
                     <th mat-header-cell *matHeaderCellDef > Nombre </th>
                     <td mat-cell *matCellDef="let row"> {{row.nombre}} </td>
                 </ng-container>
-            <ng-container matColumnDef="descripcion">
-                <th mat-header-cell *matHeaderCellDef> Descripción </th>
-                <td mat-cell *matCellDef="let row"> {{row.descripcion}} </td>
-            </ng-container>
-            <ng-container matColumnDef="tipo_plan">
-                <th mat-header-cell *matHeaderCellDef> Tipo de plan </th>
-                <td mat-cell *matCellDef="let row"> {{row.nombre_tipo_plan}} </td>
-            </ng-container>
-            <ng-container matColumnDef="activo">
-                <th mat-header-cell *matHeaderCellDef > Estado </th>
-                <td mat-cell *matCellDef="let row"> {{row.activo}} </td>
-            </ng-container>
-            <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef class="header-align-right"> Acciones </th>
-                <td mat-cell *matCellDef="let row" class="td-align-right">
-                    <button mat-icon-button (click)="consultarPlan(row._id, row.nombre, row.tipo_plan_id)"><mat-icon>search</mat-icon></button>
-                    <button mat-icon-button (click)="editar(row)"><mat-icon>edit</mat-icon></button>
-                    <button mat-icon-button (click)="inactivar(row)"><mat-icon>delete_outline</mat-icon></button>
-               </td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-            <tr class="mat-row" *matNoDataRow>
-                <td class="mat-cell" colspan="5">No se han encontrado resultados para la búsqueda "{{input.value}}"</td>
-            </tr>
+                <ng-container matColumnDef="descripcion">
+                    <th mat-header-cell *matHeaderCellDef> Descripción </th>
+                    <td mat-cell *matCellDef="let row"> {{row.descripcion}} </td>
+                </ng-container>
+                <ng-container matColumnDef="tipo_plan">
+                    <th mat-header-cell *matHeaderCellDef> Tipo de plan </th>
+                    <td mat-cell *matCellDef="let row"> {{row.nombre_tipo_plan}} </td>
+                </ng-container>
+                <ng-container matColumnDef="activo">
+                    <th mat-header-cell *matHeaderCellDef > Estado </th>
+                    <td mat-cell *matCellDef="let row"> {{row.activo}} </td>
+                </ng-container>
+                <ng-container matColumnDef="actions">
+                    <th mat-header-cell *matHeaderCellDef class="tituloAcciones">Acciones</th>
+                    <td mat-cell *matCellDef="let row" class="botonesAcciones">
+                        <button mat-icon-button *ngIf="!banderaPlanesAccionFuncionamiento" (click)="consultarPlan(row._id, row.nombre, row.tipo_plan_id)"><mat-icon>search</mat-icon></button>
+                        <button mat-icon-button *ngIf="!banderaPlanesAccionFuncionamiento" (click)="editar(row)"><mat-icon>edit</mat-icon></button>
+                        <button mat-icon-button *ngIf="!banderaPlanesAccionFuncionamiento" (click)="inactivar(row)"><mat-icon>delete_outline</mat-icon></button>
+                        <button mat-icon-button *ngIf="banderaPlanesAccionFuncionamiento" (click)="changeIcon(row)"><mat-icon>{{row.iconSelected}}</mat-icon></button>
+                    </td>
+                </ng-container>
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                <tr class="mat-row" *matNoDataRow>
+                    <td class="mat-cell" colspan="5">No se han encontrado resultados para la búsqueda "{{input.value}}"</td>
+                </tr>
             </table>
-            <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>
-          </div>
+            <mat-paginator class="paginator" [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>
+            <div class="botonesPlanesInteres" *ngIf="banderaPlanesAccionFuncionamiento">
+                <button mat-raised-button [disabled]="banderaTodosSeleccionados" (click)="seleccionarTodos()" color="primary">Seleccionar Todos</button>
+                <button mat-raised-button [disabled]="planesInteres.length==0" (click)="borrarSeleccion()" color="primary">Borrar selección</button>
+            </div>
+        </div>
     </mat-card-content>
 </mat-card>

--- a/src/app/pages/plan/listar-plan/listar-plan.component.scss
+++ b/src/app/pages/plan/listar-plan/listar-plan.component.scss
@@ -1,30 +1,32 @@
-.mat-card{
-  background-color: #F1F5F8;
+.mat-card {
+  background-color: #f1f5f8;
 }
 
-
-table {
-    width: 100%;
-  }
+table,
+.paginator {
+  width: 80%;
+  margin-left: 10%;
+}
 
 th {
-    color: white;
-    text-align: center !important;
+  color: white;
+  text-align: center !important;
+  padding: 0px !important;
 }
 
-
-.td-align-right{
-  text-align: right;
-  justify-content: flex-end;
+.botonesAcciones {
+  width: 20%;
+  text-align: center;
+  justify-content: center;
 }
 
-.header-align-right{
-  display: flex;
-  padding: 21px 0;
-  justify-content: flex-end;
+.tituloAcciones {
+  padding-right: 0px;
+  width: fit-content;
+  justify-content: center;
 }
 
-.textGuide{
+.textGuide {
   background-color: #ffff;
   border: 1px solid var(--primary);
   border-radius: 15px 15px 15px 15px;
@@ -35,14 +37,17 @@ th {
   padding: 1%;
   text-decoration: none;
   margin-bottom: 1%;
-  width: 97%;
+  width: 77%;
 }
 
-
-.mat-row:nth-child(even){
-  background-color:#E7D6D6;
+.mat-row:nth-child(even) {
+  background-color: #e7d6d6;
 }
-      
-.mat-row:nth-child(odd){
+
+.mat-row:nth-child(odd) {
   background-color: white;
+}
+
+.mat-raised-button {
+  margin: 2% 0% 2% 2%;
 }


### PR DESCRIPTION
#812 
- Se creó el componente **_tabla-unidades_** para la visualización y selección de las unidades de interés por parte del usuario. Este componente se agregó dentro de **habilitar-reporte**.
- Se reutilizó el componente **_listar-plan_** para la visualización y selección de los planes de interés por parte del usuario. Este componente se agregó dentro de **habilitar-reporte**. También se realizaron algunas modificaciones e implementaciones de banderas y condicionales para mostrar u ocultar algunos aspectos visuales y funcionalidades que se muestran en otro módulo y no se deberían mostrar en **habilitar-reporte**.
- Se modificó la lógica del componente para permitir realizar la petición teniendo en cuenta los planes y unidades de interés seleccionadas, también se modificó el botón de limpiar para los planes de acción de funcionamiento haciendo que se limpien los nuevos campos implementados.