### PR TITLE
feat: Tabla de resumen de planes en formulacion con funcionalidad

### DIFF
--- a/src/app/pages/formulacion/formulacion.component.html
+++ b/src/app/pages/formulacion/formulacion.component.html
@@ -68,7 +68,7 @@
 <br><br>
 <!-- TABLA RESUMEN -->
 <ng-container *ngIf="rol == 'PLANEACION' && !planAsignado">
-  <app-tabla-resumen></app-tabla-resumen>
+  <app-tabla-resumen [planes]="planesFormulacion" (mostrarPlan)="cargarPlan($event)"></app-tabla-resumen>
 </ng-container>
 <!-- FORMULACIÓN -->
 <mat-card class="card-oas" *ngIf="!clonar && planAsignado">

--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -8,6 +8,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import Swal from 'sweetalert2';
 import { ImplicitAutenticationService } from 'src/app/@core/utils/implicit_autentication.service';
 import { UserService } from '../services/userService';
+import { ResumenPlan } from 'src/app/@core/models/plan/resumen_plan';
 
 
 @Component({
@@ -583,14 +584,14 @@ export class FormulacionComponent implements OnInit {
   }
 
   getEstado() {
-    this.request.get(environment.PLANES_CRUD, `estado-plan/` + this.plan.estado_plan_id).subscribe((data: any) => {
-      if (data) {
-        this.estadoPlan = data.Data.nombre;
-        this.getIconEstado();
-        this.visualizeObs();
-      }
-    }),
-      (error) => {
+    this.request.get(environment.PLANES_CRUD, `estado-plan/` + this.plan.estado_plan_id).subscribe(
+      (data: any) => {
+        if (data) {
+          this.estadoPlan = data.Data.nombre;
+          this.getIconEstado();
+          this.visualizeObs();
+        }
+      }, (error) => {
         Swal.fire({
           title: 'Error en la operación',
           icon: 'error',
@@ -599,6 +600,7 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
+    )
   }
 
   getIconEstado() {
@@ -621,8 +623,8 @@ export class FormulacionComponent implements OnInit {
 
   getVersiones(planB, planRecienCreado: boolean = true) {
     let aux = planB.nombre.replace(/ /g, "%20");
-    this.request.get(environment.PLANES_MID, `formulacion/get_plan_versiones/` + this.unidad.Id + `/` + this.vigencia.Id +
-      `/` + aux).subscribe((data: any) => {
+    this.request.get(environment.PLANES_MID, `formulacion/get_plan_versiones/${this.unidad.Id}/${this.vigencia.Id}/${aux}`).subscribe(
+      (data: any) => {
         if (data) {
           this.versiones = data;
           for (var i in this.versiones) {
@@ -641,8 +643,7 @@ export class FormulacionComponent implements OnInit {
           this.versionPlan = this.plan.numero;
           this.getEstado();
         }
-      }),
-      (error) => {
+      },(error) => {
         Swal.fire({
           title: 'Error en la operación',
           icon: 'error',
@@ -651,6 +652,7 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
+    )
   }
 
   busquedaPlanes(planB) {
@@ -755,7 +757,7 @@ export class FormulacionComponent implements OnInit {
     })
     this.request.get(environment.PLANES_MID, `formato/` + plan._id).subscribe((data: any) => {
       //if (data) {
-      // Bloque if: Se ejecutará si data no es null y data[0] no es null, y data[1][0] es un objeto no vacío.  
+      // Bloque if: Se ejecutará si data no es null y data[0] no es null, y data[1][0] es un objeto no vacío.
       if (data && data[0] !== null && data[1] && data[1][0] && Object.keys(data[1][0]).length > 0) {
         Swal.close();
         this.estado = plan.estado_plan_id;
@@ -1124,16 +1126,15 @@ export class FormulacionComponent implements OnInit {
       } else if (result.dismiss === Swal.DismissReason.cancel) {
 
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
-      }
+    },(error) => {
+      Swal.fire({
+        title: 'Error en la operación',
+        icon: 'error',
+        text: `${JSON.stringify(error)}`,
+        showConfirmButton: false,
+        timer: 2500
+      })
+    })
   }
 
   messageIdentificacion(event) {
@@ -1228,16 +1229,15 @@ export class FormulacionComponent implements OnInit {
                     timer: 2500
                   })
                 }
-              }),
-                (error) => {
-                  Swal.fire({
-                    title: 'Error en la operación',
-                    icon: 'error',
-                    text: `${JSON.stringify(error)}`,
-                    showConfirmButton: false,
-                    timer: 2500
-                  })
-                }
+              },(error) => {
+                Swal.fire({
+                  title: 'Error en la operación',
+                  icon: 'error',
+                  text: `${JSON.stringify(error)}`,
+                  showConfirmButton: false,
+                  timer: 2500
+                })
+              })
             } else {
               Swal.fire({
                 title: 'Error en la operación',
@@ -1338,16 +1338,15 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
-      }
+    }, (error) => {
+      Swal.fire({
+        title: 'Error en la operación',
+        icon: 'error',
+        text: `${JSON.stringify(error)}`,
+        showConfirmButton: false,
+        timer: 2500
+      })
+    })
   }
 
   enviarRevision() {
@@ -1383,16 +1382,15 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
-      }
+    }, (error) => {
+      Swal.fire({
+        title: 'Error en la operación',
+        icon: 'error',
+        text: `${JSON.stringify(error)}`,
+        showConfirmButton: false,
+        timer: 2500
+      })
+    })
   }
 
   realizarAjustes() {
@@ -1426,7 +1424,6 @@ export class FormulacionComponent implements OnInit {
             })
           }
         })
-
       } else if (result.dismiss === Swal.DismissReason.cancel) {
         Swal.fire({
           title: 'Envio de Revisión Cancelado',
@@ -1435,16 +1432,15 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
-      }
+    }, (error) => {
+      Swal.fire({
+        title: 'Error en la operación',
+        icon: 'error',
+        text: `${JSON.stringify(error)}`,
+        showConfirmButton: false,
+        timer: 2500
+      })
+    })
   }
 
   preAval() {
@@ -1486,16 +1482,15 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
-      }
+    }, (error) => {
+      Swal.fire({
+        title: 'Error en la operación',
+        icon: 'error',
+        text: `${JSON.stringify(error)}`,
+        showConfirmButton: false,
+        timer: 2500
+      })
+    })
   }
 
 
@@ -1544,15 +1539,18 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
-      }
+    },(error) => {
+      Swal.fire({
+        title: 'Error en la operación',
+        icon: 'error',
+        text: JSON.stringify(error),
+        showConfirmButton: false,
+        timer: 2500
+      })
+    })
+  }
+
+  cargarPlan($event: Event) : void {
+    console.log($event)
   }
 }

--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1628,7 +1628,6 @@ export class FormulacionComponent implements OnInit {
       this.onChangeP(plan)
     });
 
-    // this.controlVersion.setValue()
     this.versionDesdeTabla = $event['version']
   }
 }

--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1603,9 +1603,6 @@ export class FormulacionComponent implements OnInit {
   }
 
   cargarPlan($event: Event) : void {
-    console.log($event)
-    // Cúal es la diferencia entre auxUnidades y Unidades?
-
     this.auxUnidades.filter(
       (unidad) => unidad['Id'] == $event['dependencia_id']
     ).forEach((unidad)=>{

--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -34,6 +34,7 @@ export class FormulacionComponent implements OnInit {
   planAux: any;
   unidad: any;
   vigencia: any;
+  versionDesdeTabla: number;
   steps: any[];
   json: any;
   estado: string;
@@ -626,20 +627,21 @@ export class FormulacionComponent implements OnInit {
     }
   }
 
-  getVersiones(planB, planRecienCreado: boolean = true) {
+  getVersiones(planB, planRecienCreado: boolean = false) {
     let aux = planB.nombre.replace(/ /g, "%20");
     this.request.get(environment.PLANES_MID, `formulacion/get_plan_versiones/${this.unidad.Id}/${this.vigencia.Id}/${aux}`).subscribe(
       (data: any) => {
         if (data) {
           this.versiones = data;
-          for (var i in this.versiones) {
-            var obj = this.versiones[i];
-            var num = +i + 1;
-            obj["numero"] = num.toString();
-          }
-          var len = this.versiones.length;
-          var pos = +len - 1;
-          this.plan = this.versiones[pos];
+          this.versiones.forEach((_, i) => {
+            this.versiones[i]['numero'] = (i + 1).toString();
+          });
+          this.plan =
+            this.versiones[
+              this.versionDesdeTabla == undefined || this.versionDesdeTabla > this.versiones.length
+                ? this.versiones.length - 1
+                : this.versionDesdeTabla - 1
+            ];
           this.planAsignado = true;
           this.clonar = false;
           this.banderaUltimaVersion = true;
@@ -1602,5 +1604,31 @@ export class FormulacionComponent implements OnInit {
 
   cargarPlan($event: Event) : void {
     console.log($event)
+    // Cúal es la diferencia entre auxUnidades y Unidades?
+
+    this.auxUnidades.filter(
+      (unidad) => unidad['Id'] == $event['dependencia_id']
+    ).forEach((unidad)=>{
+      this.formSelect.get('selectUnidad').setValue(unidad);
+      this.onChangeU(unidad)
+    });
+
+    this.vigencias.filter(
+      (vigencia) => vigencia['Id'] == $event['vigencia_id']
+    ).forEach((vigencia)=>{
+      this.formSelect.get('selectVigencia').setValue(vigencia);
+      this.onChangeV(vigencia)
+    });
+
+    // Podría haber un error si 2 o más planes que sean formato tengan el mismo nombre
+    this.planes.filter(
+      (plan) => plan['nombre'] == $event['nombre']
+    ).forEach((plan)=>{
+      this.formSelect.get('selectPlan').setValue(plan);
+      this.onChangeP(plan)
+    });
+
+    // this.controlVersion.setValue()
+    this.versionDesdeTabla = $event['version']
   }
 }

--- a/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.html
+++ b/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.html
@@ -67,7 +67,7 @@
             Acciones
           </th>
           <td mat-cell *matCellDef="let plan">
-            <button mat-icon-button (click)="consultar(plan)" disabled>
+            <button mat-icon-button (click)="consultar(plan)">
               <mat-icon>search</mat-icon>
             </button>
           </td>

--- a/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
+++ b/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
@@ -32,7 +32,8 @@ export class TablaResumenComponent implements OnInit, AfterViewInit {
   inputsFiltros: NodeListOf<HTMLInputElement>;
   planes: ResumenPlan[];
 
-  @Output() mostrarPlan: EventEmitter<ResumenPlan> = new EventEmitter<ResumenPlan>();
+  @Output() mostrarPlan: EventEmitter<ResumenPlan> =
+    new EventEmitter<ResumenPlan>();
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
@@ -93,18 +94,18 @@ export class TablaResumenComponent implements OnInit, AfterViewInit {
         .get(environment.PRUEBA, `formulacion/planes_formulacion`)
         .subscribe(
           (data) => {
-            if (data) {
-              this.planes = data.Data;
+            this.planes = data.Data;
+            if (this.planes.length != 0) {
               Swal.close();
-              if(this.planes.length == 0){
-                Swal.fire({
-                  title: 'No existen registros',
-                  icon: 'info',
-                  text: 'No hay planes en formulación',
-                  showConfirmButton: false,
-                  timer: 2500,
-                });
-              }
+            } else {
+              Swal.close();
+              Swal.fire({
+                title: 'No existen registros',
+                icon: 'info',
+                text: 'No hay planes en formulación',
+                showConfirmButton: false,
+                timer: 2500,
+              });
               resolve(this.planes);
             }
           },

--- a/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
+++ b/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
@@ -91,7 +91,7 @@ export class TablaResumenComponent implements OnInit, AfterViewInit {
     });
     await new Promise((resolve, reject) => {
       this.request
-        .get(environment.PRUEBA, `formulacion/planes_formulacion`)
+        .get(environment.PLANES_MID, `formulacion/planes_formulacion`)
         .subscribe(
           (data) => {
             this.planes = data.Data;

--- a/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
+++ b/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
@@ -96,6 +96,15 @@ export class TablaResumenComponent implements OnInit, AfterViewInit {
             if (data) {
               this.planes = data.Data;
               Swal.close();
+              if(this.planes.length == 0){
+                Swal.fire({
+                  title: 'No existen registros',
+                  icon: 'info',
+                  text: 'No hay planes en formulación',
+                  showConfirmButton: false,
+                  timer: 2500,
+                });
+              }
               resolve(this.planes);
             }
           },

--- a/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
+++ b/src/app/pages/formulacion/tabla-resumen/tabla-resumen.component.ts
@@ -106,8 +106,8 @@ export class TablaResumenComponent implements OnInit, AfterViewInit {
                 showConfirmButton: false,
                 timer: 2500,
               });
-              resolve(this.planes);
             }
+            resolve(this.planes);
           },
           (error) => {
             Swal.close();


### PR DESCRIPTION
Se agrega la funcionalidad a la tabla resumen, trayendo los datos del API MID de planeación y actualizando la tabla, haciendo un correcto manejo de los errores, desde el cliente. Y, con los campos pedidos, que son: unidad, vigencia, versión y nombre. También, se habilitó la opción de "ver" a cada plan.

#818

