### PR TITLE
feat: se agregó funcionalidad de definir fechas por unidad y planes/proyectos específicos para los procesos de formulación y seguimiento en PAF

### DIFF
--- a/src/app/pages/plan/habilitar-reporte/habilitar-reporte.component.html
+++ b/src/app/pages/plan/habilitar-reporte/habilitar-reporte.component.html
@@ -124,8 +124,12 @@
         </div>
       </ng-container>
       <div class="btnUnidades-PlanesProyectos">
-        <button mat-raised-button matPrefix color="primary" [disabled]="tipo !== 'seguimiento' && tipo !== 'formulacion'" (click)="banderaTabla('unidades')">Unidades a las que desea asignar el proceso</button>
-        <button mat-raised-button matPrefix color="primary" [disabled]="tipo !== 'seguimiento' && tipo !== 'formulacion'" (click)="banderaTabla('planes_proyectos')">Planes/proyectos a las que desea asignar el proceso</button>
+        <button mat-raised-button matPrefix color="primary" [disabled]="tipo !== 'seguimiento' && tipo !== 'formulacion'" 
+          (click)="banderaTabla('unidades')">Unidades a las que desea asignar el proceso
+        </button>
+        <button mat-raised-button matPrefix color="primary" [disabled]="tipo !== 'seguimiento' && tipo !== 'formulacion'"
+          (click)="banderaTabla('planes_proyectos')" >Planes/proyectos a las que desea asignar el proceso
+        </button>
       </div>
       <!-- Tabla Unidades de interés -->
       <mat-card class="card-oas" [style.width.%]="97"
@@ -135,7 +139,8 @@
       <!-- Tabla Planes/Proyectos de interés -->
       <mat-card class="card-oas" [style.width.%]="97"
         *ngIf="(tipo=='seguimiento' || tipo == 'formulacion') && vigenciaSelected && banderaPlanesInteres">
-          <app-listar-plan [banderaPlanesAccionFuncionamiento]="true" (planesInteresSeleccionados)="manejarCambiosPlanesInteres($event)"></app-listar-plan>
+          <app-listar-plan [banderaPlanesAccionFuncionamiento]="true" (planesInteresSeleccionados)="manejarCambiosPlanesInteres($event)"
+          [planesPeriodoSeguimiento]="planesInteresPeriodoSeguimiento"></app-listar-plan>
       </mat-card>
     </form>
   </mat-card-content>

--- a/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.ts
+++ b/src/app/pages/plan/habilitar-reporte/tabla-unidades/tabla-unidades.component.ts
@@ -59,6 +59,8 @@ export class TablaUnidadesComponent implements OnInit {
       title: 'Cargando unidades',
       timerProgressBar: true,
       showConfirmButton: false,
+      allowEscapeKey: false,
+      allowOutsideClick: false,
       willOpen: () => {
         Swal.showLoading();
       },

--- a/src/app/pages/plan/listar-plan/listar-plan.component.html
+++ b/src/app/pages/plan/listar-plan/listar-plan.component.html
@@ -30,6 +30,10 @@
                     <th mat-header-cell *matHeaderCellDef > Estado </th>
                     <td mat-cell *matCellDef="let row"> {{row.activo}} </td>
                 </ng-container>
+                <ng-container *ngIf="banderaPlanesAccionFuncionamiento" matColumnDef="fecha_modificacion">
+                    <th mat-header-cell *matHeaderCellDef > Fecha modificación (DD/MM/AAAA) </th>
+                    <td mat-cell *matCellDef="let row"> {{row.fecha_modificacion?.toString() || 'No definida aún'}} </td>
+                </ng-container>
                 <ng-container matColumnDef="actions">
                     <th mat-header-cell *matHeaderCellDef class="tituloAcciones">Acciones</th>
                     <td mat-cell *matCellDef="let row" class="botonesAcciones">
@@ -49,6 +53,7 @@
             <div class="botonesPlanesInteres" *ngIf="banderaPlanesAccionFuncionamiento">
                 <button mat-raised-button [disabled]="banderaTodosSeleccionados" (click)="seleccionarTodos()" color="primary">Seleccionar Todos</button>
                 <button mat-raised-button [disabled]="planesInteres.length==0" (click)="borrarSeleccion()" color="primary">Borrar selección</button>
+                <button mat-raised-button [disabled]="planesPeriodoSeguimiento == undefined || planesPeriodoSeguimiento.length==0" (click)="cambiarDataTabla()" color="primary">{{textBotonMostrarData}}</button>
             </div>
         </div>
     </mat-card-content>

--- a/src/app/pages/plan/listar-plan/listar-plan.component.ts
+++ b/src/app/pages/plan/listar-plan/listar-plan.component.ts
@@ -8,8 +8,6 @@ import { RequestManager } from '../../services/requestManager';
 import { environment } from '../../../../environments/environment';
 import Swal from 'sweetalert2';
 import { Router } from '@angular/router';
-import { error } from 'console';
-
 export interface Planes {
   _id: string
   activo: string
@@ -35,7 +33,7 @@ export interface Plan {
   styleUrls: ['./listar-plan.component.scss']
 })
 export class ListarPlanComponent implements OnInit {
-  displayedColumns: string[] = ['nombre', 'descripcion', 'tipo_plan', 'activo', 'actions'];
+  displayedColumns: string[];
   dataSource: MatTableDataSource<any>;
   uid: number; // id del objeto
   planes: any[];
@@ -47,7 +45,10 @@ export class ListarPlanComponent implements OnInit {
   iconoPlanesAccionFuncionamiento: string = 'compare_arrows';
   planesInteres: any;
   banderaTodosSeleccionados: boolean;
-
+  planesMostrar: Planes[];
+  textBotonMostrarData: string = 'Mostrar Planes Interés Habilitados/Reporte';
+  
+  @Input() planesPeriodoSeguimiento: any;
   @Input() banderaPlanesAccionFuncionamiento: boolean;
   @Output() planesInteresSeleccionados = new EventEmitter<any[]>();
   @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -65,6 +66,12 @@ export class ListarPlanComponent implements OnInit {
 
   ngOnInit(): void {
     console.log('Inicia el componente Listar Planes/Proyectos');
+    this.planesMostrar = [];
+    if(this.banderaPlanesAccionFuncionamiento){
+      this.displayedColumns = ['nombre', 'descripcion', 'tipo_plan', 'activo', 'fecha_modificacion', 'actions']
+    } else {
+      this.displayedColumns = ['nombre', 'descripcion', 'tipo_plan', 'activo', 'actions'];
+    }
     this.loadData();
   }
 
@@ -209,32 +216,11 @@ export class ListarPlanComponent implements OnInit {
 
   loadData() {
     this.mostrarMensajeCarga();
-
     this.request.get(environment.PLANES_MID, `formulacion/planes`).subscribe(
       (data: any) => {
         if (data) {
           this.planes = data.Data;
-          // this.request.get(environment.PLANES_CRUD, `tipo-plan?query=_id:${data.Data.tipo_plan_id}`).subscribe((dat: any) => {
-          //   if (dat){
-          //     this.tipoPlan = dat.Data;
-          //     this.nombreTipoPlan = dat.Data.nombre
-          //     this.ajustarData();
-          //   }
-          // },(error) => {
-          //   Swal.fire({
-          //     title: 'Error en la operación', 
-          //     text: 'No se encontraron datos registrados',
-          //     icon: 'warning',
-          //     showConfirmButton: false,
-          //     timer: 2500
-          //   })
-
-          // })
-          // this.nombreTipoPlan = this.tipoPlan.nombre
           this.ajustarData();
-          if(this.banderaPlanesAccionFuncionamiento){
-            this.planes = data.Data.filter((plan: Planes) => plan.activo == "Activo");
-          }
           this.cerrarMensajeCarga();
         }
       },
@@ -262,7 +248,7 @@ export class ListarPlanComponent implements OnInit {
   }
 
   cerrarMensajeCarga(): void {
-    this.dataSource = new MatTableDataSource(this.planes);
+    this.dataSource = new MatTableDataSource(this.planesMostrar);
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
     this.cargando = false;
@@ -270,9 +256,14 @@ export class ListarPlanComponent implements OnInit {
   }
 
   ajustarData() {
-    this.cambiarValor("activo", true, "Activo")
-    this.cambiarValor("activo", false, "Inactivo")
-    this.cambiarValor("iconSelected", undefined, "compare_arrows")
+    this.cambiarValor("activo", true, "Activo");
+    if(this.banderaPlanesAccionFuncionamiento){
+      this.planes = this.planes.filter((plan: Planes) => plan.activo == "Activo");
+      this.cambiarValor("iconSelected", undefined, "compare_arrows");
+    } else {
+      this.cambiarValor("activo", false, "Inactivo");
+    }
+    this.planesMostrar = this.planes;
   }
 
   editar(fila): void {
@@ -353,18 +344,14 @@ export class ListarPlanComponent implements OnInit {
 
   seleccionarTodos() {
     this.banderaTodosSeleccionados = true;
-    this.planesInteres = this.planes.map((element) => ({
+    this.planesInteres = this.planesMostrar.map((element) => ({
       _id: element._id,
       nombre: element.nombre,
     }));
-
     // Itera sobre los elementos y cambia el icono
     this.planes.forEach((element) => {
       element.iconSelected = 'done';
     });
-
-    // Emite los cambios
-    console.log('Todos seleccionados: ', this.planesInteres);
     this.emitirCambiosPlanesInteres();
   }
 
@@ -374,16 +361,44 @@ export class ListarPlanComponent implements OnInit {
     this.planes.forEach((element) => {
       element.iconSelected = 'compare_arrows';
     });
-
     // Limpia el array de unidades de interés
     this.planesInteres = [];
-
-    // Emite los cambios
-    console.log('Ninguno seleccionado: ', this.planesInteres);
     this.emitirCambiosPlanesInteres();
   }
 
   emitirCambiosPlanesInteres() {
     this.planesInteresSeleccionados.emit(this.planesInteres);
+  }
+
+  cambiarDataTabla(){
+    if(this.planesPeriodoSeguimiento.length >= 0 
+      && this.textBotonMostrarData === 'Mostrar Planes Interés Habilitados/Reporte'){
+      this.textBotonMostrarData = 'Mostrar todos los planes';
+      this.planesMostrar = this.planes.filter(plan1 => {
+        const plan2 = this.planesPeriodoSeguimiento.find(plan => plan._id === plan1._id);
+        if (plan2) {
+            plan1.fecha_modificacion = this.formatearFecha(plan2['fecha_modificacion']);
+        }
+        return this.planesPeriodoSeguimiento.some(plan2 => plan2._id === plan1._id);
+      });
+      this.dataSource = new MatTableDataSource(this.planesMostrar);
+      this.dataSource.paginator = this.paginator;
+      this.dataSource.sort = this.sort;
+    } else {
+      this.textBotonMostrarData = 'Mostrar Planes Interés Habilitados/Reporte';
+      this.dataSource = new MatTableDataSource(this.planes);
+      this.dataSource.paginator = this.paginator;
+      this.dataSource.sort = this.sort;
+    }
+  }
+
+  formatearFecha(fechaOriginal: string): string {
+    const fechaObjeto = new Date(fechaOriginal);
+
+    const dia = fechaObjeto.getDate().toString().padStart(2, '0');
+    const mes = (fechaObjeto.getMonth() + 1).toString().padStart(2, '0');
+    const anio = fechaObjeto.getFullYear();
+
+    return `${dia}/${mes}/${anio}`;
   }
 }


### PR DESCRIPTION
#816 #817 
Se realizó un filtro de unidad que muestra una tabla con todas las unidades, también tiene un botón que permite seleccionar todas las unidades. Además, se puede seleccionar más de una unidad sin tener que seleccionar todas las unidades.
Se realizó un filtro de plan o proyecto para traer solo aquellos proyectos o planes asociados con la unidad o unidades seleccionadas y se añadió un botón para seleccionar todos los proyectos resultantes. Además, también se puede seleccionar más de un proyecto sin tener que seleccionar todos los proyectos.