### PR TITLE
Hotfix: Actualización de endpoints en módulo de formulación de planes de acción y administrar sistema

### DIFF
--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1522,10 +1522,10 @@ export class FormulacionComponent implements OnInit {
             const mensaje = error.error.Data ? error.error.Data : error.message
             Swal.fire({
               title: 'Error en la operación',
-              text: `${mensaje}`,
+              text: `${mensaje}, por favor diríjase al módulo de administración y diligencie las fechas correspondientes al periodo de seguimiento para la vigencia requerida.`,
               icon: 'warning',
               showConfirmButton: false,
-              timer: 2500
+              timer: 4000
             });
             reject();
           })

--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1483,7 +1483,7 @@ export class FormulacionComponent implements OnInit {
 
   avalar() {
     Swal.fire({
-      title: 'Pre Aval',
+      title: 'Aval',
       text: `¿Desea darle Aval a este plan?`,
       icon: 'warning',
       confirmButtonText: `Sí`,
@@ -1491,32 +1491,44 @@ export class FormulacionComponent implements OnInit {
       showCancelButton: true
     }).then((result) => {
       if (result.isConfirmed) {
-        this.plan.estado_plan_id = "6153355601c7a2365b2fb2a1";
-        this.request.put(environment.PLANES_CRUD, `plan`, this.plan, this.plan._id).subscribe((data: any) => {
-          if (data) {
+        this.mostrarMensajeCarga();
+        return new Promise((resolve, reject) => {
+          this.request.post(environment.PLANES_MID, `seguimiento/avalar/` + this.plan._id, {}).subscribe((data: any) => {
+            Swal.close();
+            if (data.Success == true) {
+              Swal.fire({
+                title: 'Plan Avalado',
+                icon: 'success',
+                showConfirmButton: false,
+                timer: 2500
+              })
+              this.plan.estado_plan_id = "6153355601c7a2365b2fb2a1";
+              this.busquedaPlanes(this.plan);
+              this.loadData();
+              this.addActividad = false;
+              resolve(data);
+            } else {
+              Swal.fire({
+                title: 'Error en la operación',
+                icon: 'error',
+                text: `Error creando reportes de seguimiento`,
+                showConfirmButton: false,
+                timer: 2500
+              })
+              reject();
+            }
+          }, (error) => {
+            Swal.close();
+            const mensaje = error.error.Data ? error.error.Data : error.message
             Swal.fire({
-              title: 'Plan Avalado',
-              icon: 'success',
-            }).then((result) => {
-              if (result.value) {
-                this.busquedaPlanes(data.Data);
-                this.loadData();
-                this.addActividad = false;
-                let aux = {}
-                this.request.post(environment.PLANES_MID, `seguimiento/crear_reportes/` + this.plan._id + `/61f236f525e40c582a0840d0`, this.plan).subscribe((data: any) => {
-                  if (!data) {
-                    Swal.fire({
-                      title: 'Error en la operación',
-                      icon: 'error',
-                      text: `Error creando reportes de seguimiento`,
-                      showConfirmButton: false,
-                      timer: 2500
-                    })
-                  }
-                })
-              }
-            })
-          }
+              title: 'Error en la operación',
+              text: `${mensaje}`,
+              icon: 'warning',
+              showConfirmButton: false,
+              timer: 2500
+            });
+            reject();
+          })
         })
       } else if (result.dismiss === Swal.DismissReason.cancel) {
         Swal.fire({
@@ -1526,15 +1538,17 @@ export class FormulacionComponent implements OnInit {
           timer: 2500
         })
       }
-    }),
-      (error) => {
-        Swal.fire({
-          title: 'Error en la operación',
-          icon: 'error',
-          text: `${JSON.stringify(error)}`,
-          showConfirmButton: false,
-          timer: 2500
-        })
+    })
+  }
+
+  mostrarMensajeCarga(): void {
+    Swal.fire({
+      title: 'Procesando petición...',
+      allowEscapeKey: false,
+      allowOutsideClick: false,
+      didOpen: () => {
+        Swal.showLoading();
       }
+    });
   }
 }

--- a/src/app/pages/services/errorManager.ts
+++ b/src/app/pages/services/errorManager.ts
@@ -6,8 +6,7 @@ import { Injectable, forwardRef, Inject, NgZone } from '@angular/core';
   providedIn: 'root',
 })
 export class HttpErrorManager {
-  constructor(
-   ) {}
+  constructor() {}
 
   public handleError(error: HttpErrorResponse) {
     if (error.error instanceof ErrorEvent) {
@@ -23,6 +22,7 @@ export class HttpErrorManager {
     return throwError({
       status: error.status?error.status:'Error',
       message: 'Something bad happened; please try again later.',
+      error: error.error,
     });
   };
 }


### PR DESCRIPTION
- Se actualizó el endpoint en la función avalar() del componente formulación, anteriormente apuntaba a 2 endpoints para realizar el aval del plan y crear los reportes de seguimiento respectivamente, ahora solo apunta a un endpoint en planeacion_mid.
- Se actualizó el endpoint de la función loadTrimestres del componente habilitar-reporte para obtener los trimestres correspondientes a una vigencia.
- Se creó una función de limpieza de fechas para limpiar los inputs de las fechas cada vez que se cambie de vigencia o de tipo de proceso (formulación/seguimiento).