### PR TITLE
feat: Ajuste hotfix ambiente de pruebas (monolito)

### DIFF
--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1796,7 +1796,7 @@ export class FormulacionComponent implements OnInit, OnDestroy {
 
   avalar() {
     Swal.fire({
-      title: 'Pre Aval',
+      title: 'Aval',
       text: `¿Desea darle Aval a este plan?`,
       icon: 'warning',
       confirmButtonText: `Sí`,
@@ -1804,8 +1804,10 @@ export class FormulacionComponent implements OnInit, OnDestroy {
       showCancelButton: true
     }).then((result) => {
       if (result.isConfirmed) {
+        this.mostrarMensajeCarga();
         return new Promise((resolve, reject) => {
           this.request.post(environment.PLANES_MID, `seguimiento/avalar/` + this.plan._id, {}).subscribe((data: any) => {
+            Swal.close();
             if (data.Success == true) {
               Swal.fire({
                 title: 'Plan Avalado',
@@ -1850,14 +1852,6 @@ export class FormulacionComponent implements OnInit, OnDestroy {
           timer: 2500
         })
       }
-    }, (error) => {
-      Swal.fire({
-        title: 'Error en la operación',
-        icon: 'error',
-        text: JSON.stringify(error),
-        showConfirmButton: false,
-        timer: 2500
-      })
     })
   }
   /**
@@ -1914,5 +1908,16 @@ export class FormulacionComponent implements OnInit, OnDestroy {
     } else {
       console.error('No se han cargado los planes');
     }
+  }
+
+  mostrarMensajeCarga(): void {
+    Swal.fire({
+      title: 'Procesando petición...',
+      allowEscapeKey: false,
+      allowOutsideClick: false,
+      didOpen: () => {
+        Swal.showLoading();
+      }
+    });
   }
 }

--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1804,32 +1804,43 @@ export class FormulacionComponent implements OnInit, OnDestroy {
       showCancelButton: true
     }).then((result) => {
       if (result.isConfirmed) {
-        this.plan.estado_plan_id = "6153355601c7a2365b2fb2a1";
-        this.request.put(environment.PLANES_CRUD, `plan`, this.plan, this.plan._id).subscribe((data: any) => {
-          if (data) {
-            Swal.fire({
-              title: 'Plan Avalado',
-              icon: 'success',
-            }).then((result) => {
-              if (result.value) {
-                this.busquedaPlanes(data.Data, false);
+        return new Promise((resolve, reject) => {
+          this.request.post(environment.PLANES_MID, `seguimiento/avalar/` + this.plan._id, {}).subscribe((data: any) => {
+            if (data.Success == true) {
+              Swal.fire({
+                title: 'Plan Avalado',
+                icon: 'success',
+                showConfirmButton: false,
+                timer: 2500
+              }).then((result) => {
+                this.plan.estado_plan_id = "6153355601c7a2365b2fb2a1";
+                this.busquedaPlanes(this.plan, false);
                 this.loadData();
                 this.addActividad = false;
-                let aux = {}
-                this.request.post(environment.PLANES_MID, `seguimiento/crear_reportes/` + this.plan._id + `/61f236f525e40c582a0840d0`, this.plan).subscribe((data: any) => {
-                  if (!data) {
-                    Swal.fire({
-                      title: 'Error en la operación',
-                      icon: 'error',
-                      text: `Error creando reportes de seguimiento`,
-                      showConfirmButton: false,
-                      timer: 2500
-                    })
-                  }
-                })
-              }
-            })
-          }
+              })
+              resolve(data);
+            } else {
+              Swal.fire({
+                title: 'Error en la operación',
+                icon: 'error',
+                text: `Error creando reportes de seguimiento`,
+                showConfirmButton: false,
+                timer: 2500
+              })
+              reject();
+            }
+          }, (error) => {
+            Swal.close();
+            const mensaje = error.error.Data ? error.error.Data : error.message
+            Swal.fire({
+              title: 'Error en la operación',
+              text: `${mensaje}, por favor diríjase al módulo de administración y diligencie las fechas correspondientes al periodo de seguimiento para la vigencia requerida.`,
+              icon: 'warning',
+              showConfirmButton: false,
+              timer: 4000
+            });
+            reject();
+          })
         })
       } else if (result.dismiss === Swal.DismissReason.cancel) {
         Swal.fire({

--- a/src/app/pages/plan/habilitar-reporte/funcionamiento/funcionamiento.component.ts
+++ b/src/app/pages/plan/habilitar-reporte/funcionamiento/funcionamiento.component.ts
@@ -240,8 +240,8 @@ export class FuncionamientoComponent implements OnInit {
     }
   }
 
-  loadTrimestres(vigencia: Vigencia) {
-    this.habilitarReporteService.loadTrimestres(vigencia);
+  async loadTrimestres(vigencia: Vigencia) {
+    await this.habilitarReporteService.loadTrimestres(vigencia);
     this.habilitarReporteService.getTrimestresSubject().subscribe(
       (data: any) => {
         if(data.error) {
@@ -250,7 +250,7 @@ export class FuncionamientoComponent implements OnInit {
           Swal.close();
           Swal.fire({
             title: 'Error en la operación',
-            text: `No se encontraron trimestres para esta vigencia, por favor comunicarse con computo@udistrital.edu.co`,
+            text: `No se encontraron datos registrados: ${data.error.Data}, por favor comunicarse con computo@udistrital.edu.co`,
             icon: 'warning',
             showConfirmButton: false,
             timer: 3000
@@ -273,8 +273,7 @@ export class FuncionamientoComponent implements OnInit {
             Swal.close();
           }
         }
-      },
-      (error) => {
+      }, (error) => {
         Swal.fire({
           title: 'Error en la operación',
           text: `No se encontraron datos registrados ${JSON.stringify(error)}, por favor comunicarse con computo@udistrital.edu.co`,

--- a/src/app/pages/plan/habilitar-reporte/funcionamiento/funcionamiento.component.ts
+++ b/src/app/pages/plan/habilitar-reporte/funcionamiento/funcionamiento.component.ts
@@ -243,28 +243,41 @@ export class FuncionamientoComponent implements OnInit {
   loadTrimestres(vigencia: Vigencia) {
     this.habilitarReporteService.loadTrimestres(vigencia);
     this.habilitarReporteService.getTrimestresSubject().subscribe(
-      (data: DataRequest) => {
-        if(data == null) {
+      (data: any) => {
+        if(data.error) {
           this.guardarDisabled = true;
           this.periodos = [];
           Swal.close();
           Swal.fire({
             title: 'Error en la operación',
-            text: `No se encontraron trimestres para esta vigencia`,
+            text: `No se encontraron trimestres para esta vigencia, por favor comunicarse con computo@udistrital.edu.co`,
             icon: 'warning',
             showConfirmButton: false,
-            timer: 2500
+            timer: 3000
           })
-        } else if (data.Data != null) {
-          this.periodos = data.Data;
-          this.guardarDisabled = false;
-          Swal.close();
+        } else {
+          if(data == null) {
+            this.guardarDisabled = true;
+            this.periodos = [];
+            Swal.close();
+            Swal.fire({
+              title: 'Error en la operación',
+              text: `No se encontraron trimestres para esta vigencia, por favor comunicarse con computo@udistrital.edu.co`,
+              icon: 'warning',
+              showConfirmButton: false,
+              timer: 3000
+            })
+          } else if (data.Data != null) {
+            this.periodos = data.Data;
+            this.guardarDisabled = false;
+            Swal.close();
+          }
         }
       },
       (error) => {
         Swal.fire({
           title: 'Error en la operación',
-          text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
+          text: `No se encontraron datos registrados ${JSON.stringify(error)}, por favor comunicarse con computo@udistrital.edu.co`,
           icon: 'warning',
           showConfirmButton: false,
           timer: 2500

--- a/src/app/pages/plan/habilitar-reporte/habilitar-reporte.service.ts
+++ b/src/app/pages/plan/habilitar-reporte/habilitar-reporte.service.ts
@@ -17,7 +17,7 @@ export class HabilitarReporteService {
     private request: RequestManager,
   ) { }
 
-  loadTrimestres(vigencia: Vigencia) {
+  async loadTrimestres(vigencia: Vigencia) {
     Swal.fire({
       title: 'Cargando períodos',
       timerProgressBar: true,
@@ -25,7 +25,7 @@ export class HabilitarReporteService {
       willOpen: () => {
         Swal.showLoading();
       },
-    })
+    });
     this.request.get(environment.PLANES_MID, `seguimiento/trimestres/` + vigencia.Id).subscribe((data: DataRequest) => {
       if (data.Data != null) {
         this.trimestresSubject.next(data);

--- a/src/app/pages/plan/habilitar-reporte/habilitar-reporte.service.ts
+++ b/src/app/pages/plan/habilitar-reporte/habilitar-reporte.service.ts
@@ -26,14 +26,14 @@ export class HabilitarReporteService {
         Swal.showLoading();
       },
     })
-    this.request.get(environment.PLANES_MID, `seguimiento/get_periodos/` + vigencia.Id).subscribe((data: DataRequest) => {
+    this.request.get(environment.PLANES_MID, `seguimiento/trimestres/` + vigencia.Id).subscribe((data: DataRequest) => {
       if (data.Data != null) {
         this.trimestresSubject.next(data);
       } else {
         this.trimestresSubject.next(null);
       }
     }, (error) => {
-      this.trimestresSubject.next(null);
+      this.trimestresSubject.next(error);
     });
   }
 

--- a/src/app/pages/plan/habilitar-reporte/inversion/inversion.component.ts
+++ b/src/app/pages/plan/habilitar-reporte/inversion/inversion.component.ts
@@ -231,28 +231,41 @@ export class InversionComponent implements OnInit {
   loadTrimestres(vigencia: Vigencia) {
     this.habilitarReporteService.loadTrimestres(vigencia);
     this.habilitarReporteService.getTrimestresSubject().subscribe(
-      (data: DataRequest) => {
-        if (data == null ) {
+      (data: any) => {
+        if(data.error) {
           this.guardarDisabled = true;
           this.periodos = [];
           Swal.close();
           Swal.fire({
             title: 'Error en la operación',
-            text: `No se encontraron trimestres para esta vigencia`,
+            text: `No se encontraron trimestres para esta vigencia, por favor comunicarse con computo@udistrital.edu.co`,
             icon: 'warning',
             showConfirmButton: false,
-            timer: 2500
+            timer: 3000
           })
-        } else if (data.Data != "") {
-          this.periodos = data.Data;
-          this.guardarDisabled = false;
-          Swal.close();
+        } else {
+          if(data == null) {
+            this.guardarDisabled = true;
+            this.periodos = [];
+            Swal.close();
+            Swal.fire({
+              title: 'Error en la operación',
+              text: `No se encontraron trimestres para esta vigencia, por favor comunicarse con computo@udistrital.edu.co`,
+              icon: 'warning',
+              showConfirmButton: false,
+              timer: 3000
+            })
+          } else if (data.Data != null) {
+            this.periodos = data.Data;
+            this.guardarDisabled = false;
+            Swal.close();
+          }
         }
       },
       (error) => {
         Swal.fire({
           title: 'Error en la operación',
-          text: `No se encontraron datos registrados ${JSON.stringify(error)}`,
+          text: `No se encontraron datos registrados ${JSON.stringify(error)}, por favor comunicarse con computo@udistrital.edu.co`,
           icon: 'warning',
           showConfirmButton: false,
           timer: 2500

--- a/src/app/pages/seguimiento/listar-plan-accion-anual/seguimiento.component.ts
+++ b/src/app/pages/seguimiento/listar-plan-accion-anual/seguimiento.component.ts
@@ -295,10 +295,15 @@ export class SeguimientoComponentList implements OnInit, AfterViewInit {
                       _id: this.plan.formato_id,
                       nombre: this.plan.nombre
                     }
+                    let unidad = {
+                      Id: this.unidad.Id,
+                      Nombre: this.unidad.Nombre
+                    }
                     let body = {
                       periodo_id: periodos[i].Id,
                       tipo_seguimiento_id: '61f236f525e40c582a0840d0',
                       planes_interes: JSON.stringify([plan]),
+                      unidades_interes: JSON.stringify([unidad]),
                       activo: true
                     }
                     await new Promise((resolve, reject) => {

--- a/src/app/pages/seguimiento/listar-plan-accion-anual/seguimiento.component.ts
+++ b/src/app/pages/seguimiento/listar-plan-accion-anual/seguimiento.component.ts
@@ -283,7 +283,7 @@ export class SeguimientoComponentList implements OnInit, AfterViewInit {
         },
       })
       await new Promise((resolve,reject)=>{
-        this.request.get(environment.PLANES_MID, `seguimiento/get_periodos/` + this.vigencia.Id).subscribe(async (data: DataRequest) => {
+        this.request.get(environment.PLANES_MID, `seguimiento/trimestres/` + this.vigencia.Id).subscribe(async (data: DataRequest) => {
           if (data) {
             if (data.Data != "" && data.Data != null) {
               let periodos = data.Data;


### PR DESCRIPTION
#1016 
- Se actualizó el endpoint en la función avalar() del componente formulación, anteriormente apuntaba a 2 endpoints para realizar el aval del plan y crear los reportes de seguimiento respectivamente, ahora solo apunta a un endpoint en planeacion_mid.
- Se actualizó el endpoint de la función loadTrimestres() del componente habilitar-reporte para obtener los trimestres correspondientes a una vigencia.