### PR TITLE
feat: se agregó validación para avalar reporte de seguimiento únicamente desde PLANEACION

### DIFF
--- a/src/app/pages/seguimiento/generar-trimestre/generar-trimestre.component.ts
+++ b/src/app/pages/seguimiento/generar-trimestre/generar-trimestre.component.ts
@@ -558,7 +558,7 @@ export class GenerarTrimestreComponent implements OnInit, AfterViewInit {
     var mensaje = `¿Desea guardar la información del componente cualitativo?`
     if (this.rol === 'PLANEACION' || this.rol === 'ASISTENTE_PLANEACION') {
       mensaje = `¿Desea avalar la actividad?`
-      if (this.veririficarObservaciones()) {
+      if (this.verificarObservaciones()) {
         mensaje = `¿Desea guardar las observaciones del componente cualitativo?`
       }
     }
@@ -617,7 +617,7 @@ export class GenerarTrimestreComponent implements OnInit, AfterViewInit {
     var mensaje = `¿Desea guardar la información del componente cuantitativo?`
     if (this.rol === 'PLANEACION' || this.rol === 'ASISTENTE_PLANEACION') {
       mensaje = `¿Desea avalar la actividad?`
-      if (this.veririficarObservaciones()) {
+      if (this.verificarObservaciones()) {
         mensaje = `¿Desea guardar las observaciones del componente cuantitativo?`
       }
     }
@@ -1062,7 +1062,7 @@ export class GenerarTrimestreComponent implements OnInit, AfterViewInit {
 
   guardarRevisionJefeDependencia() {
     var mensaje = `¿Desea verificar la actividad?`
-    if (this.veririficarObservaciones()) {
+    if (this.verificarObservaciones()) {
       mensaje = `¿Desea enviar las observaciones realizadas para este reporte?`
     }
 
@@ -1127,7 +1127,7 @@ export class GenerarTrimestreComponent implements OnInit, AfterViewInit {
 
   guardarRevision() {
     var mensaje = `¿Desea avalar la actividad?`
-    if (this.veririficarObservaciones()) {
+    if (this.verificarObservaciones()) {
       mensaje = `¿Desea enviar las observaciones realizadas para este reporte?`
     }
 
@@ -1191,21 +1191,33 @@ export class GenerarTrimestreComponent implements OnInit, AfterViewInit {
       }
   }
 
-  veririficarObservaciones() {
-    if (this.seguimiento.cualitativo.observaciones != "" && this.seguimiento.cualitativo.observaciones != "Sin observación") {
+  verificarObservaciones() {
+    if (
+      this.seguimiento.cualitativo.observaciones != "" &&
+      this.seguimiento.cualitativo.observaciones != "Sin observación" &&
+      this.seguimiento.cualitativo.observaciones != undefined
+    ) {
       return true;
     }
 
     for (let index = 0; index < this.seguimiento.cuantitativo.indicadores.length; index++) {
       const indicador = this.seguimiento.cuantitativo.indicadores[index];
-      if (indicador.observaciones != "" && indicador.observaciones != "Sin observación") {
+      if (
+        indicador.observaciones != "" &&
+        indicador.observaciones != "Sin observación" &&
+        indicador.observaciones != undefined
+      ) {
         return true;
       }
     }
 
     for (let index = 0; index < this.seguimiento.evidencia.length; index++) {
       const evidencia = this.seguimiento.evidencia[index];
-      if (evidencia.Observacion != "" && evidencia.Observacion != "Sin observación") {
+      if (
+        evidencia.Observacion != "" &&
+        evidencia.Observacion != "Sin observación" &&
+        evidencia.Observacion != undefined
+      ) {
         return true;
       }
     }
@@ -1316,7 +1328,7 @@ export class GenerarTrimestreComponent implements OnInit, AfterViewInit {
 
   /*verificarActividad() {
     var mensaje = `¿Desea verificar la actividad?`
-    if (this.veririficarObservaciones()) {
+    if (this.verificarObservaciones()) {
       mensaje = `¿Desea enviar las observaciones realizadas para este reporte?`
     }
 

--- a/src/app/pages/seguimiento/gestion-seguimiento/gestion-seguimiento.component.ts
+++ b/src/app/pages/seguimiento/gestion-seguimiento/gestion-seguimiento.component.ts
@@ -312,7 +312,19 @@ export class SeguimientoComponentGestion implements OnInit {
       }
   }
 
-  finalizarRevision() {
+  async finalizarRevision() {
+    if (await this.validacionActividades() && this.rol === 'ASISTENTE_PLANEACION') { 
+      /* Si todas las actividades están avaladas y el rol es ASISTENTE_PLANEACION
+      NO se puede finalizar la revisión (Avalar Reporte) debe hacerlo el rol PLANEACION. */
+      Swal.fire({
+        title: 'Finalización de revisión cancelada',
+        text: `Solo el JEFE_PLANEACION puede avalar el reporte de seguimiento`,
+        icon: 'error',
+        showConfirmButton: false,
+        timer: 3500
+      });
+      return;
+    }
     Swal.fire({
       title: 'Finalizar revisión',
       text: `¿Confirma que desea finalizar la revisión del seguimiento al Plan de Acción?`,
@@ -356,7 +368,7 @@ export class SeguimientoComponentGestion implements OnInit {
         });
       } else if (result.dismiss === Swal.DismissReason.cancel) {
         Swal.fire({
-          title: 'Finalizalización de revisión cancelada',
+          title: 'Finalización de revisión cancelada',
           icon: 'error',
           showConfirmButton: false,
           timer: 2500
@@ -417,7 +429,7 @@ export class SeguimientoComponentGestion implements OnInit {
         });
       } else if (result.dismiss === Swal.DismissReason.cancel) {
         Swal.fire({
-          title: 'Finalizalización de revisión cancelada',
+          title: 'Finalización de revisión cancelada',
           icon: 'error',
           showConfirmButton: false,
           timer: 2500
@@ -527,7 +539,6 @@ export class SeguimientoComponentGestion implements OnInit {
       if (result.isConfirmed) {
         this.request.get(environment.PLANES_CRUD, `estado-seguimiento?query=activo:true,codigo_abreviacion:RJU`).subscribe((data: any) => {
           if (data) {
-            console.log(data);
             this.seguimiento.estado_seguimiento_id = data.Data[0]._id;;
             this.request.put(environment.PLANES_CRUD, `seguimiento`, this.seguimiento, this.seguimiento._id).subscribe((data: any) => {
               if (data) {
@@ -679,5 +690,28 @@ export class SeguimientoComponentGestion implements OnInit {
           timer: 2500
         })
       }
+  }
+
+  async validacionActividades() {
+    let aux = true;
+    let actividadAvalada;
+    await new Promise((resolve) => {
+      this.request
+        .get(
+          environment.PLANES_CRUD,
+          `estado-seguimiento?query=codigo_abreviacion:AAV,activo:true`
+        ).subscribe((data: any) => {
+          if (data?.Data) {
+            actividadAvalada = data.Data[0]
+            resolve(actividadAvalada);
+          }
+        });
+    });
+    this.allActividades.forEach(actividad => {
+      if (actividad.estado.id != actividadAvalada._id) {
+        aux = false;
+      }
+    });
+    return aux;
   }
 }


### PR DESCRIPTION
#1133 
- Se agregó validación para avalar reporte de seguimiento únicamente desde el rol PLANEACION
- Se cambió el nombre de la función _veririficarObservaciones_ por _verificarObservaciones_
- Se agregaron validaciones en condicionales al momento de verificar/avalar una actividad