### PR TITLE
feat: se agregó validación del tipo de plan en construir-plan, validación en el form de gen. de reportes y lectura de vinculaciones activas en formulacion/seguimiento de un tercero

### DIFF
--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -162,7 +162,7 @@ export class FormulacionComponent implements OnInit, OnDestroy {
     if(this.rol == 'PLANEACION' || this.rol == 'ASISTENTE_PLANEACION') {
       await this.loadUnidades();
     }else if (this.rol == 'JEFE_DEPENDENCIA') {
-      await this.validarUnidad()
+      await this.validarUnidad();
     }
 
     this.miObservableSubscription = this.verificarFormulario.formData$.subscribe(formData => {
@@ -333,11 +333,13 @@ export class FormulacionComponent implements OnInit, OnDestroy {
               )
               .subscribe((vinculacion: any) => {
                 if (vinculacion['Data'] != '') {
-                  this.request
+                  let vinculaciones: any[] = vinculacion['Data'];
+                  vinculaciones.forEach(vinculacion => {
+                    this.request
                     .get(
                       environment.OIKOS_SERVICE,
                       `dependencia_tipo_dependencia?query=DependenciaId:` +
-                        vinculacion['Data']['DependenciaId']
+                      vinculacion['DependenciaId']
                     )
                     .subscribe((dataUnidad: any) => {
                       if (dataUnidad) {
@@ -347,7 +349,6 @@ export class FormulacionComponent implements OnInit, OnDestroy {
                           return fechaA.getTime() - fechaB.getTime()
                         });
                         // TODO: verificar que las unidades vienen organizadas de mayor a menor por Fecha de Modificación
-                        // console.log(unidadesOrdenadas)
                         let unidad = unidadesOrdenadas[0]['DependenciaId'];
                         unidad['TipoDependencia'] = unidadesOrdenadas[0]['TipoDependenciaId']['Id'];
                         for (let i = 0; i < dataUnidad.length; i++) {
@@ -360,9 +361,10 @@ export class FormulacionComponent implements OnInit, OnDestroy {
                         this.formSelect.get('selectUnidad').setValue(unidad);
                         this.onChangeU(unidad);
                         this.moduloVisible = true;
-                        resolve(unidad);
                       }
                     });
+                  });
+                  resolve(true);
                 } else {
                   this.moduloVisible = false;
                   Swal.fire({
@@ -695,6 +697,8 @@ export class FormulacionComponent implements OnInit, OnDestroy {
       this.versionPlan = '';
       if (this.vigenciaSelected && this.planSelected) {
         await this.busquedaPlanes(this.planAux);
+      } else if (this.vigenciaSelected) {
+        await this.loadPlanes();
       }
     }
   }

--- a/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.html
+++ b/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.html
@@ -25,7 +25,7 @@
       <ng-container *ngIf="vTipoPlan">
         <mat-form-field [style.width.%]="40">
           <mat-label id="tipo-input-label">Tipo</mat-label>
-          <mat-select formControlName="tipo_plan_id" (selectionChange)="select($event.value)" required>
+          <mat-select formControlName="tipo_plan_id" (selectionChange)="select($event.value)" (openedChange)="onOpenedChange($event)" required>
             <mat-option>--</mat-option>
             <mat-option *ngFor="let tipo of tiposPlanes" [value]="tipo._id">
               {{tipo.nombre}}

--- a/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.ts
+++ b/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.ts
@@ -119,6 +119,17 @@ export class EditarDialogComponent implements OnInit {
     this.dialogRef.close();
   }
 
+  onOpenedChange(isOpened: boolean) {
+    if (isOpened) {
+      Swal.fire({
+        title: 'Información',
+        text: 'Por favor verificar el tipo de plan de acción. Actualmente NO soportado por el módulo de reportes.',
+        icon: 'info',
+        confirmButtonText: 'OK'
+      });
+    }
+  }
+
   getErrorMessage(campo: FormControl) {
     if (campo.hasError('required',)) {
       return 'Campo requerido';
@@ -240,7 +251,7 @@ export class EditarDialogComponent implements OnInit {
   }
 
   loadTiposPlan() {
-    this.request.get(environment.PLANES_CRUD, `tipo-plan`).subscribe((data: any) => {
+    this.request.get(environment.PLANES_CRUD, `tipo-plan?query=activo:true`).subscribe((data: any) => {
       if (data) {
         this.tiposPlanes = data.Data;
       }

--- a/src/app/pages/reportes/reporte-plan-anual/plan-anual.component.ts
+++ b/src/app/pages/reportes/reporte-plan-anual/plan-anual.component.ts
@@ -245,6 +245,8 @@ export class PlanAnualComponent implements OnInit {
       }
       this.form.get('estado').setValue(null);
       this.form.get('estado').disable();
+      this.form.get('unidad').enable();
+      this.form.get('unidad').setValue(null);
       this.evaluacion = true;
     } else {
       if (this.rol == 'PLANEACION') {
@@ -264,6 +266,7 @@ export class PlanAnualComponent implements OnInit {
     let estado = this.form.get('estado').value;
     let plan = this.form.get('plan').value;
     let body = {
+      plan_id: plan._id,
       tipo_plan_id: await this.codigosService.getId('PLANES_CRUD', 'tipo-plan', 'PAF_SP'),
       vigencia: (vigencia.Id).toString(),
       nombre: plan.nombre
@@ -281,17 +284,17 @@ export class PlanAnualComponent implements OnInit {
       if (tipoReporte === 'unidad') {
         body["unidad_id"] = (unidad.Id).toString();
         body["estado_plan_id"] = estado;
-        body["categoria"] = "Plan de acción unidad";
+        body["categoria"] = "Plan_Accion_Unidad";
       } else if (tipoReporte === 'general') {
         body["estado_plan_id"] = estado;
-        body["categoria"] = "Plan de acción general";
+        body["categoria"] = "Plan_Accion_General";
       }
     } else if (categoria === 'necesidades') {
       body["estado_plan_id"] = estado;
       body["categoria"] = "Necesidades";
     } else if (categoria === 'evaluacion') {
       body["unidad_id"] = (unidad.Id).toString();
-      body["categoria"] = "Evaluación";
+      body["categoria"] = "Evaluacion";
     }
 
     this.request.post(environment.PLANES_MID, `reportes/validar_reporte`, body).subscribe((res: any) => {


### PR DESCRIPTION
- Se agregó validación del tipo de plan en construir-plan
- Se agregó validación en el formulario de generación de reportes en módulo de reportes
- Se estandarizaron las categorías de reportes enviadas a planeacion_mid, ejemplo. Antes estaba: _Plan de acción unidad_ y ahora _Plan_Accion_Unidad_, con el propósito de no hacer comparaciones con caracteres especiales y/o espacios.
- Se corrigió lectura de vinculaciones activas en formulacion/seguimiento de un tercero en formulacion_controller.go