### PR TITLE
feat: se agregó diferenciación de vigencias a los PI y PED

### DIFF
--- a/src/app/pages/formulacion/formulacion.component.ts
+++ b/src/app/pages/formulacion/formulacion.component.ts
@@ -1440,10 +1440,25 @@ async onChangeU(unidad) {
   }
 
   cargarPlanesDesarrollo() {
+    let vigencia = {
+      Id: this.vigencia.Id,
+      Nombre: this.vigencia.Nombre
+    }
     return new Promise(async(resolve)=>{
       this.request.get(environment.PLANES_CRUD, `plan?query=activo:true,tipo_plan_id:${await this.codigosService.getId('PLANES_CRUD', 'tipo-plan', 'PD_SP')}`).subscribe((data: any) => {
         if (data) {
-          this.planesDesarrollo = data.Data;
+          let planesDesarrolloSinFiltro = data.Data;
+          let planesDesarrolloFiltrados = [];
+          planesDesarrolloSinFiltro.filter(plan => {
+            if (plan.vigencia_aplica) {
+              let vigencia_aplica = JSON.parse(plan.vigencia_aplica);
+              const existe = vigencia_aplica.some(item => item.Id === vigencia.Id && item.Nombre === vigencia.Nombre);
+              if (existe) {
+                planesDesarrolloFiltrados.push(plan);
+              };
+            };
+          });
+          this.planesDesarrollo = planesDesarrolloFiltrados;
           this.formArmonizacion.get('selectPED').setValue(this.planesDesarrollo[0])
           this.onChangePD(this.planesDesarrollo[0]);
           resolve(this.planesDesarrollo);
@@ -1453,10 +1468,25 @@ async onChangeU(unidad) {
   }
 
   cargarPlanesIndicativos() {
+    let vigencia = {
+      Id: this.vigencia.Id,
+      Nombre: this.vigencia.Nombre
+    }
     return new Promise(async (resolve)=>{
       this.request.get(environment.PLANES_CRUD, `plan?query=tipo_plan_id:${await this.codigosService.getId('PLANES_CRUD', 'tipo-plan', 'PLI_SP')}`).subscribe((data: any) => {
         if (data) {
-          this.planesIndicativos = data.Data;
+          let planesIndicativosSinFiltro = data.Data;
+          let planesIndicativosFiltrados = [];
+          planesIndicativosSinFiltro.filter(plan => {
+            if (plan.vigencia_aplica) {
+              let vigencia_aplica = JSON.parse(plan.vigencia_aplica);
+              const existe = vigencia_aplica.some(item => item.Id === vigencia.Id && item.Nombre === vigencia.Nombre);
+              if (existe) {
+                planesIndicativosFiltrados.push(plan);
+              };
+            };
+          });
+          this.planesIndicativos = planesIndicativosFiltrados;
           this.formArmonizacion.get('selectPI').setValue(this.planesIndicativos[0])
           this.onChangePI(this.planesIndicativos[0]);
           resolve(this.planesIndicativos);
@@ -1871,7 +1901,7 @@ async onChangeU(unidad) {
   realizarAjustes() {
     Swal.fire({
       title: 'Realizar Ajustes',
-      text: `¿Desea realizar ajustes a el Plan?`,
+      text: `¿Desea realizar ajustes al Plan?`,
       icon: 'warning',
       confirmButtonText: `Sí`,
       cancelButtonText: `No`,

--- a/src/app/pages/ped/ped.component.html
+++ b/src/app/pages/ped/ped.component.html
@@ -26,13 +26,18 @@
                 <th mat-header-cell *matHeaderCellDef mat-sort-header> Estado </th>
                 <td mat-cell *matCellDef="let row"> {{row.activo}} </td>
             </ng-container>
+            <ng-container matColumnDef="vigencia_aplica">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header> Vigencia Aplica </th>
+                <td mat-cell *matCellDef="let row"> {{formatearVigencias(row)}} </td>
+            </ng-container>
             <ng-container matColumnDef="actions">
                 <th mat-header-cell *matHeaderCellDef class="header-align-right"> Acciones </th>
                 <td mat-cell *matCellDef="let row" class="td-align-right">
+                    <button mat-icon-button (click)="duplicar(row)"><mat-icon>file_copy</mat-icon></button>
                     <button mat-icon-button (click)="consultar(row)"><mat-icon>search</mat-icon></button>
                     <button mat-icon-button (click)="editar(row)"><mat-icon>edit</mat-icon></button>
                     <button mat-icon-button (click)="inactivar(row)"><mat-icon>delete_outline</mat-icon></button>
-               </td>
+                </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
@@ -41,6 +46,6 @@
             </tr>
             </table>
             <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>
-          </div>
+        </div>
     </mat-card-content>
 </mat-card>

--- a/src/app/pages/plan-indicativo/consultar-pi/consultar-pi.component.html
+++ b/src/app/pages/plan-indicativo/consultar-pi/consultar-pi.component.html
@@ -26,13 +26,18 @@
                 <th mat-header-cell *matHeaderCellDef mat-sort-header> Estado </th>
                 <td mat-cell *matCellDef="let row"> {{row.activo}} </td>
             </ng-container>
+            <ng-container matColumnDef="vigencia_aplica">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header> Vigencia Aplica </th>
+                <td mat-cell *matCellDef="let row"> {{formatearVigencias(row)}} </td>
+            </ng-container>
             <ng-container matColumnDef="actions">
                 <th mat-header-cell *matHeaderCellDef class="header-align-right"> Acciones </th>
                 <td mat-cell *matCellDef="let row" class="td-align-right">
+                    <button mat-icon-button (click)="duplicar(row)"><mat-icon>file_copy</mat-icon></button>
                     <button mat-icon-button (click)="consultar(row)"><mat-icon>search</mat-icon></button>
                     <button mat-icon-button (click)="editar(row)"><mat-icon>edit</mat-icon></button>
                     <button mat-icon-button (click)="inactivar(row)"><mat-icon>delete_outline</mat-icon></button>
-               </td>
+                </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
@@ -41,6 +46,6 @@
             </tr>
             </table>
             <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>
-          </div>
+        </div>
     </mat-card-content>
 </mat-card>

--- a/src/app/pages/plan-indicativo/consultar-pi/consultar-pi.component.ts
+++ b/src/app/pages/plan-indicativo/consultar-pi/consultar-pi.component.ts
@@ -19,7 +19,7 @@ import { CodigosService } from 'src/app/@core/services/codigos.service';
 
 export class ConsultarPIComponent implements OnInit {
 
-  displayedColumns: string[] = ['nombre', 'descripcion', 'activo', 'actions'];
+  displayedColumns: string[] = ['nombre', 'descripcion', 'activo', 'vigencia_aplica', 'actions'];
   dataSource: MatTableDataSource<any>;
   uid: number; // id del objeto
   planes: any[];
@@ -54,6 +54,11 @@ export class ConsultarPIComponent implements OnInit {
       if (result == undefined){
         return undefined;
       } else {
+        if (result.vigencia_aplica && Array.isArray(result.vigencia_aplica)) {
+          if (result.vigencia_aplica.length > 0) {
+            result.vigencia_aplica = JSON.stringify(result.vigencia_aplica.map(vigencia => JSON.parse(vigencia)));
+          }
+        }
         this.putData(result, 'editar');
       }
     });
@@ -269,6 +274,77 @@ export class ConsultarPIComponent implements OnInit {
         timer: 2500
       });
     }
+  }
+
+  async duplicar(row) {
+    let plan_id = row._id;
+    Swal.fire({
+      title: 'Clonar plan',
+      text: `¿Está seguro de clonar el plan?`,
+      showCancelButton: true,
+      confirmButtonText: `Si`,
+      cancelButtonText: `No`,
+      allowOutsideClick: false,
+    }).then((result) => {
+        if (result.isConfirmed) {
+          Swal.fire({
+            title: 'Clonando Plan Indicativo',
+            timerProgressBar: true,
+            showConfirmButton: false,
+            allowEscapeKey: false,
+            allowOutsideClick: false,
+            willOpen: () => {
+              Swal.showLoading();
+            },
+          });
+          return new Promise(async(resolve, reject)=>{
+            this.request.post(environment.PLANES_MID, `formulacion/clonar-pi-ped/${plan_id}`, {}).subscribe((data: any) => {
+              if (data.Data && data.Success == true) {
+                Swal.fire({
+                  title: 'Clonar plan',
+                  text: `El plan indicativo se ha clonado correctamente`,
+                  icon: 'success',
+                  showConfirmButton: false,
+                  timer: 2500
+                }).then(() => {
+                  window.location.reload();
+                  resolve(true);
+                });
+              } else {
+                Swal.fire({
+                  title: 'Error en la operación',
+                  text: `No se ha podido clonar el plan indicativo: ${data.Message}`,
+                  icon: 'error',
+                  showConfirmButton: false,
+                  timer: 2500
+                });
+                resolve(false);
+              }
+            }, (error) => {
+              Swal.fire({
+                title: 'Error en la operación',
+                text: 'No se encontraron datos registrados',
+                icon: 'error',
+                showConfirmButton: false,
+                timer: 2500
+              })
+              reject(false);
+            });
+          });
+        } else if (result.dismiss === Swal.DismissReason.cancel) {
+          Swal.fire({
+            title: 'Clonación cancelada',
+            icon: 'error',
+            showConfirmButton: false,
+            timer: 2500
+          })
+        }
+    });
+  }
+
+  formatearVigencias(row) {
+    if(!row.vigencia_aplica) return 'Por definir';
+    return JSON.parse(row.vigencia_aplica).map(vigencia => vigencia.Nombre).join(', ');
   }
 
   cambiarValor(valorABuscar, valorViejo, valorNuevo) {

--- a/src/app/pages/plan/construir-plan-proyecto/construir-plan-proyecto.component.ts
+++ b/src/app/pages/plan/construir-plan-proyecto/construir-plan-proyecto.component.ts
@@ -58,6 +58,11 @@ export class ConstruirPlanProyectoComponent implements OnInit {
       if (result == undefined){
         return undefined;
       } else {
+        if (result.vigencia_aplica && Array.isArray(result.vigencia_aplica)) {
+          if (result.vigencia_aplica.length > 0) {
+            result.vigencia_aplica = JSON.stringify(result.vigencia_aplica.map(vigencia => JSON.parse(vigencia)));
+          }
+        }
         this.putData(result, 'editar');
       }
     });

--- a/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.html
+++ b/src/app/pages/plan/construir-plan/editar-dialog/editar-dialog.component.html
@@ -25,13 +25,27 @@
       <ng-container *ngIf="vTipoPlan">
         <mat-form-field [style.width.%]="40">
           <mat-label id="tipo-input-label">Tipo</mat-label>
-          <mat-select formControlName="tipo_plan_id" (selectionChange)="select($event.value)" (openedChange)="onOpenedChange($event)" required>
+          <mat-select formControlName="tipo_plan_id" (selectionChange)="compararTipoPlan_PED_PI()" (openedChange)="onOpenedChange($event)" required>
             <mat-option>--</mat-option>
             <mat-option *ngFor="let tipo of tiposPlanes" [value]="tipo._id">
               {{tipo.nombre}}
             </mat-option>
           </mat-select>
           <mat-hint>Seleccione el tipo de proyecto o plan</mat-hint>
+        </mat-form-field>
+      </ng-container>
+      <ng-container *ngIf="vVigenciaAplicaTipoPlan">
+        <mat-form-field appearance="fill" [style.width.%]="100">
+          <mat-label id="year-input-label">Vigencia a la que aplica el plan</mat-label>
+          <mat-select formControlName="vigencia_aplica" multiple (openedChange)="onOpenedChangeVigencia($event)" required>
+              <mat-option *ngFor="let vigencia of vigencias" [value]="vigenciaToJson(vigencia)" [disabled]="isDisabledVigencia(vigencia)">
+                  {{ vigencia.Nombre }}
+              </mat-option>
+          </mat-select>
+          <mat-error *ngIf="formEditar.get('vigencia_aplica').invalid">
+              {{ getErrorMessage(formEditar.get('vigencia_aplica')) }}
+          </mat-error>
+          <mat-hint>Seleccione la vigencia a la que aplica el PI o PED</mat-hint>
         </mat-form-field>
       </ng-container>
       <ng-container *ngIf="data">

--- a/src/app/pages/plan/crear-plan/crear-plan.component.html
+++ b/src/app/pages/plan/crear-plan/crear-plan.component.html
@@ -36,6 +36,21 @@
                         </mat-error>
                     </mat-form-field>
                 </mat-grid-tile>
+                <mat-grid-tile *ngIf="formCrearPlan.get('tipo').value.codigo_abreviacion == 'PD_SP' || formCrearPlan.get('tipo').value.codigo_abreviacion == 'PLI_SP'">
+                    <mat-form-field appearance="fill" [style.width.%]="200">
+                        <mat-label id="year-input-label">Vigencia a la que aplica el plan</mat-label>
+                        <mat-select formControlName="vigencia_aplica" multiple (openedChange)="onOpenedChangeVigencia($event)" required>
+                            <mat-option *ngFor="let vigencia of vigencias" [value]="vigenciaToJson(vigencia)">
+                                {{ vigencia.Nombre }}
+                            </mat-option>
+                        </mat-select>
+                        <mat-error *ngIf="formCrearPlan.get('vigencia_aplica').invalid">
+                            {{ getErrorMessage(formCrearPlan.get('vigencia_aplica')) }}
+                        </mat-error>
+                        <mat-hint>Seleccione la vigencia a la que aplica el PI o PED</mat-hint>
+                    </mat-form-field>
+                </mat-grid-tile>
+                
                 <mat-grid-tile>
                     <mat-form-field appearance="fill" [style.width.%]="200">
                         <mat-label id="desc-input-label">Descripción</mat-label>

--- a/src/app/pages/plan/crear-plan/crear-plan.component.ts
+++ b/src/app/pages/plan/crear-plan/crear-plan.component.ts
@@ -96,6 +96,12 @@ export class CrearPlanComponent implements OnInit {
         activo: JSON.parse(this.formCrearPlan.get('radioEstado').value),
         formato: JSON.parse(this.formCrearPlan.get('radioFormato').value)
       }
+      let vigencia_aplica = this.formCrearPlan.get('vigencia_aplica').value;
+      if (Array.isArray(vigencia_aplica)) {
+        if (vigencia_aplica.length > 0) {
+          dataPlan['vigencia_aplica'] = JSON.stringify(vigencia_aplica.map(vigencia => JSON.parse(vigencia)));
+        }
+      }
       this.request.post(environment.PLANES_CRUD, 'plan', dataPlan).subscribe(
         (data) => {
           if (data) {
@@ -273,9 +279,11 @@ export class CrearPlanComponent implements OnInit {
 
 
   async ngOnInit(){
+    this.loadPeriodos();
     this.formCrearPlan = this.formBuilder.group({
       nombre: ['', Validators.required],
       desc: ['', Validators.required],
+      vigencia_aplica: [[]],
       tipo: ['', Validators.required],
       radioEstado: ['', Validators.required],
       radioFormato: ['', Validators.required],
@@ -283,4 +291,18 @@ export class CrearPlanComponent implements OnInit {
     });
   }
 
+  vigenciaToJson(vigencia: { Id: number, Nombre: string }): string {
+    return JSON.stringify({ Id: vigencia.Id, Nombre: vigencia.Nombre });
+  }
+
+  onOpenedChangeVigencia(isOpened: boolean) {
+    if (isOpened) {
+      Swal.fire({
+        title: 'Información',
+        text: 'Una vez guardadas las vigencias a las que aplicará el plan NO está permitido desmarcarlas. Para más información comunicarse con computo@udistrital.edu.co',
+        icon: 'info',
+        confirmButtonText: 'OK'
+      });
+    }
+  }
 }


### PR DESCRIPTION
- Se agregó diferenciación de vigencias a los PI y PED en la armonización de nuevas actividades en la formulación de un plan.
- Se agregó funcionalidad para duplicar PI y PED desde los módulos de consulta de dichos planes.
- Se agregó funcionalidad que NO permite desmarcar vigencias ya seleccionadas en los PI y PED.
- Se muestra la columna Vigencia Aplica en la Consulta de PI y PED.